### PR TITLE
fix for using static linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,8 @@ if(BUILD_COMMON_LWS)
             ${OPENSSL_CRYPTO_LIBRARY}
             ${OPENSSL_SSL_LIBRARY}
             ${LIBWEBSOCKET_LIBRARIES}
-            ${LIBCURL_LIBRARIES})
+            ${LIBCURL_LIBRARIES}
+            kvspicUtils)
 endif()
 
 # producer only uses curl right now

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,10 @@ message(STATUS "Kinesis Video Producer path is ${KINESIS_VIDEO_PRODUCER_C_SRC}")
 message(STATUS "Kinesis Video Open Source path is ${KINESIS_VIDEO_OPEN_SOURCE_SRC}")
 
 if(BUILD_DEPENDENCIES)
-  set(OPEN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/open-source)
+
+  if(NOT OPEN_SOURCE_DIR) # set in parent cmake script
+    set(OPEN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/open-source)
+  endif()
 
   if(NOT EXISTS ${OPEN_SOURCE_DIR})
     file(MAKE_DIRECTORY ${OPEN_SOURCE_DIR}/local)
@@ -73,7 +76,7 @@ if(BUILD_DEPENDENCIES)
               ${CMAKE_SOURCE_DIR}/cmake-scripts/libopenssl-CMakeLists.txt
               ${OPEN_SOURCE_DIR}/libopenssl/CMakeLists.txt COPYONLY)
       execute_process(
-              COMMAND ${CMAKE_COMMAND} -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
+              COMMAND ${CMAKE_COMMAND} -DBUILD_STATIC=${BUILD_STATIC} -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
               RESULT_VARIABLE result
               WORKING_DIRECTORY ${OPEN_SOURCE_DIR}/libopenssl)
       if(result)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,7 @@ message(STATUS "Kinesis Video Open Source path is ${KINESIS_VIDEO_OPEN_SOURCE_SR
 
 if(BUILD_DEPENDENCIES)
 
-  if(NOT OPEN_SOURCE_DIR) # set in parent cmake script
-    set(OPEN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/open-source)
-  endif()
+  set(OPEN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/open-source)
 
   if(NOT EXISTS ${OPEN_SOURCE_DIR})
     file(MAKE_DIRECTORY ${OPEN_SOURCE_DIR}/local)
@@ -76,7 +74,7 @@ if(BUILD_DEPENDENCIES)
               ${CMAKE_SOURCE_DIR}/cmake-scripts/libopenssl-CMakeLists.txt
               ${OPEN_SOURCE_DIR}/libopenssl/CMakeLists.txt COPYONLY)
       execute_process(
-              COMMAND ${CMAKE_COMMAND} -DBUILD_STATIC=${BUILD_STATIC} -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
+              COMMAND ${CMAKE_COMMAND} -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
               RESULT_VARIABLE result
               WORKING_DIRECTORY ${OPEN_SOURCE_DIR}/libopenssl)
       if(result)


### PR DESCRIPTION
I added kvspicUtils to kvsCommonLws' target_link_libraries() list. This resolves a link error in amazon-kinesis-video-streams-webrtc-sdk-c when using static linking.

Fixes #9 