### PR TITLE
Fix static build missing -pthreads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,8 @@ if(BUILD_COMMON_LWS)
             ${OPENSSL_SSL_LIBRARY}
             ${LIBWEBSOCKET_LIBRARIES}
             ${LIBCURL_LIBRARIES}
-            kvspicUtils)
+            kvspicUtils
+	    -pthread)
 endif()
 
 # producer only uses curl right now


### PR DESCRIPTION
When building with BUILD_STATIC_LIBS, kvsCommonLws doesn't get linked with pthreads, but needs to be.
-add pthread to kvsCommonLws's target_link_libraries()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
