### PR TITLE
Destroy LWS context on exit to avoid context leaks in OpenSSL

### DIFF
--- a/src/source/Common/Lws/LwsCall.c
+++ b/src/source/Common/Lws/LwsCall.c
@@ -76,7 +76,11 @@ CleanUp:
         // Trigger termination
         ATOMIC_STORE_BOOL(&pCallInfo->pRequestInfo->terminating, TRUE);
 
+        // Cancel the ongoing service if any
         lws_cancel_service(lwsContext);
+
+        // Destroy the context
+        lws_context_destroy(lwsContext);
     }
 
     LEAVES();


### PR DESCRIPTION
Issue # https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/295

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
