### PR TITLE
[Issue-65] Add command line parser

### DIFF
--- a/samples/KvsVideoOnlyStreamingSample.c
+++ b/samples/KvsVideoOnlyStreamingSample.c
@@ -17,7 +17,6 @@ STATUS readFrameData(PFrame pFrame, PCHAR frameFilePath)
     CHAR filePath[MAX_PATH_LEN + 1];
     UINT32 index;
     UINT64 size;
-
     CHK(pFrame != NULL, STATUS_NULL_ARG);
 
     index = pFrame->index % NUMBER_OF_FRAME_FILES + 1;
@@ -39,6 +38,15 @@ CleanUp:
     return retStatus;
 }
 
+void helper() {
+    printf("List of available options:\n" \
+           "1. --stream_name      : Set name of stream. If not selected, default stream name is set\n" \
+           "2. --file_log         : No args needed. If set, file logging is enabled\n" \
+           "3. --file_log_path    : Ensure --file_log option is provided. Set file path\n" \
+           "4. --duration         : Streaming duration in seconds\n" \
+           "5. --frame_file_path  : Frame file path\n " \
+           "6. --help             : Look at the list of available args\n");
+}
 // Forward declaration of the default thread sleep function
 VOID defaultThreadSleep(UINT64);
 
@@ -57,10 +65,71 @@ INT32 main(INT32 argc, CHAR *argv[])
     BYTE frameBuffer[200000]; // Assuming this is enough
     UINT32 frameSize = SIZEOF(frameBuffer), frameIndex = 0, fileIndex = 0;
     UINT64 streamStopTime, streamingDuration = DEFAULT_STREAM_DURATION;
+    INT32 opt_result;
+    CHAR opt[256];
+    PCHAR fileLogPath = (PCHAR) FILE_LOGGER_LOG_FILE_DIRECTORY_PATH;
+    BOOL fileLogEnable = FALSE;
+    STRCPY(frameFilePath, (PCHAR) "../samples/h264SampleFrames");
 
     if (argc < 2) {
-        defaultLogPrint(LOG_LEVEL_ERROR, "", "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET %s <stream_name> <duration_in_seconds> <frame_files_path>\n", argv[0]);
-        CHK(FALSE, STATUS_INVALID_ARG);
+        helper();
+        goto CleanUp;
+    }
+    while((opt_result = parseCommandLineOptions(argc, argv, opt)) != -1) {
+        if(STRCMP(opt, "help") == 0) {
+            helper();
+            goto CleanUp;
+        }
+
+        else if(STRCMP(opt, "stream_name") == 0) {
+            if(opt_result != 0) {
+                streamName = argv[opt_result];
+            }
+            else {
+                printf("Please set the stream name\n");
+                CHK(FALSE, STATUS_INVALID_ARG);
+            }
+        }
+
+        else if(STRCMP(opt, "file_log") == 0) {
+            fileLogEnable = TRUE;
+        }
+
+        else if(STRCMP(opt, "file_log_path") == 0) {
+            if(opt_result != 0) {
+                fileLogPath = (PCHAR) argv[opt_result];
+            }
+            else {
+                printf("Please set the file log path\n");
+                CHK(FALSE, STATUS_INVALID_ARG);
+            }
+        }
+        else if(STRCMP(opt, "duration") == 0) {
+            if(opt_result != 0) {
+                CHK_STATUS(STRTOUI64(argv[opt_result], NULL, 10, &streamingDuration));
+                streamingDuration *= HUNDREDS_OF_NANOS_IN_A_SECOND;
+            }
+            else {
+                printf("Please set the required streaming duration in seconds\n");
+                CHK(FALSE, STATUS_INVALID_ARG);
+            }
+        }
+        else if(STRCMP(opt, "frame_file_path") == 0) {
+            if(opt_result != 0) {
+                STRNCPY(frameFilePath, argv[opt_result], STRLEN(argv[opt_result]) + 1);
+            }
+            else {
+                printf("Please set a valid file path\n");
+                CHK(FALSE, STATUS_INVALID_ARG);
+            }
+        }
+        MEMSET(opt, '\0', SIZEOF(opt));
+    }
+
+    if(fileLogEnable) {
+        if(createFileLogger(FILE_LOGGER_STRING_BUFFER_SIZE, FILE_LOGGER_LOG_FILE_COUNT, fileLogPath, TRUE, TRUE, NULL) != STATUS_SUCCESS) {
+            printf("Unable to set file logger....no logging will be available\n");
+        }
     }
 
     if ((accessKey = getenv(ACCESS_KEY_ENV_VAR)) == NULL || (secretKey = getenv(SECRET_KEY_ENV_VAR)) == NULL) {
@@ -68,24 +137,11 @@ INT32 main(INT32 argc, CHAR *argv[])
         CHK(FALSE, STATUS_INVALID_ARG);
     }
 
-    MEMSET(frameFilePath, 0x00, MAX_PATH_LEN + 1);
-    if (argc < 4) {
-        STRCPY(frameFilePath, (PCHAR) "../samples/h264SampleFrames");
-    } else {
-        STRNCPY(frameFilePath, argv[3], MAX_PATH_LEN);
-    }
-
     cacertPath = getenv(CACERT_PATH_ENV_VAR);
     sessionToken = getenv(SESSION_TOKEN_ENV_VAR);
-    streamName = argv[1];
+
     if ((region = getenv(DEFAULT_REGION_ENV_VAR)) == NULL) {
         region = (PCHAR) DEFAULT_AWS_REGION;
-    }
-
-    if (argc >= 3) {
-        // Get the duration and convert to an integer
-        CHK_STATUS(STRTOUI64(argv[2], NULL, 10, &streamingDuration));
-        streamingDuration *= HUNDREDS_OF_NANOS_IN_A_SECOND;
     }
 
     streamStopTime = defaultGetTime() + streamingDuration;

--- a/src/include/com/amazonaws/kinesis/video/common/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/common/Include.h
@@ -828,6 +828,20 @@ PUBLIC_API STATUS createFileLogger(UINT64, UINT64, PCHAR, BOOL, BOOL, logPrintFu
 PUBLIC_API STATUS freeFileLogger();
 
 /**
+ * Parses command line options. The command line options must be prefixed with `--`
+ * For example: ./my_test_sample --arg1 <val> --arg2 --arg3 <val>
+ * The parser can take options with no value for it
+ * If an option does not get a value, the return value is 0
+ * If an option has a value set, the return value is the index of the <val>
+ *
+ * NOTE: THe 3rd argument passed to this function will have to be allocated/deallocated by the user
+ *
+ *
+ * @return -1 if we reach the end of options, else index of the <val> or 0 for no <val>
+ */
+PUBLIC_API INT32 parseCommandLineOptions(INT32, const PCHAR*, PCHAR);
+
+/**
  * Helper macros to be used in pairs at the application start and end
  */
 #define SET_FILE_LOGGER()               createFileLogger(FILE_LOGGER_STRING_BUFFER_SIZE, FILE_LOGGER_LOG_FILE_COUNT, (PCHAR) FILE_LOGGER_LOG_FILE_DIRECTORY_PATH, TRUE, TRUE, NULL)

--- a/src/source/Common/Util.c
+++ b/src/source/Common/Util.c
@@ -114,3 +114,28 @@ PCHAR getSslCertNameFromType(SSL_CERTIFICATE_TYPE sslCertificateType)
 
     return retStr;
 }
+
+INT32 parseCommandLineOptions(INT32 argc, const PCHAR* argv, PCHAR chosenOption) {
+    if(argc < 1 || argv == NULL || *argv == NULL || chosenOption == NULL) {
+        return -1;
+    }
+    static INT32 optind = 1;
+    INT32 index = 0;
+    if(optind == argc) {
+        index = -1;
+    }
+    else {
+        // Check if the argv parameter is a command line option
+        if(argv[optind][0] == '-' && argv[optind][1] == '-') {
+            STRNCPY(chosenOption, &argv[optind][2], (STRLEN(argv[optind]) -1));
+            // If argv is a command line option, check if next arg is a value for the option.
+            // If yes, we set the index to the value, else, we do not do anything. The application must
+            // check if index value is 0 accordingly
+            if(((optind + 1) < argc) && argv[optind + 1][0] != '-' && argv[optind + 1][1] != '-') {
+                index = optind + 1;
+            }
+        }
+        optind++;
+    }
+    return index;
+}


### PR DESCRIPTION
*Issue #, if available: #65 *

*Description of changes:*
- Currently, we require the command line options to be in a specific order. This creates a hassle because we will require all options to set a specific option. To avoid any platform dependency, this PR aims at creating a custom command line option parser. 
- Modified samples to move to this approach

Note: The parser mandates requirement of prefix `--` to the option.

Resolves #65 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
