### PR TITLE
Checking whether we have a session token by also checking whether the…

### DIFF
--- a/src/source/Common/AwsV4Signer.c
+++ b/src/source/Common/AwsV4Signer.c
@@ -220,7 +220,7 @@ STATUS signAwsRequestInfoQueryParam(PRequestInfo pRequestInfo)
     expirationInSeconds = MAX(MIN_AWS_SIGV4_CREDENTIALS_EXPIRATION_IN_SECONDS, expirationInSeconds);
 
     // Add the params
-    if (pRequestInfo->pAwsCredentials->sessionToken == NULL) {
+    if (pRequestInfo->pAwsCredentials->sessionToken == NULL || pRequestInfo->pAwsCredentials->sessionTokenLen == 0) {
         len = (UINT32) SNPRINTF(pEndUrl, remaining, AUTH_QUERY_TEMPLATE,
                                 AWS_SIG_V4_ALGORITHM, pEncodedCreds, dateTimeStr, expirationInSeconds,
                                 signedHeadersLen, pSignedHeaders);


### PR DESCRIPTION
… length is 0. This fixes file credential provider issue with no session tokens specified when the file credential provider specifies an empty string instead of NULL which is OK and should be handled properly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
