### PR TITLE
Returning specific status codes for file credential provider

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/common/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/common/Include.h
@@ -39,6 +39,9 @@ extern "C" {
 #define STATUS_IOT_CREATE_LWS_CONTEXT_FAILED                                        STATUS_COMMON_PRODUCER_BASE + 0x0000001f
 #define STATUS_INVALID_CA_CERT_PATH                                                 STATUS_COMMON_PRODUCER_BASE + 0x00000020
 #define STATUS_FILE_LOGGER_INDEX_FILE_INVALID_SIZE                                  STATUS_COMMON_PRODUCER_BASE + 0x00000021
+#define STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED                            STATUS_COMMON_PRODUCER_BASE + 0x00000022
+#define STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH                         STATUS_COMMON_PRODUCER_BASE + 0x00000023
+#define STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT                         STATUS_COMMON_PRODUCER_BASE + 0x00000024
 
 // Continue errors from the new common base
 #define STATUS_COMMON_BASE                                                          0x16000000

--- a/src/source/Common/FileCredentialProvider.c
+++ b/src/source/Common/FileCredentialProvider.c
@@ -137,7 +137,7 @@ STATUS readFileCredentials(PFileCredentialProvider pFileCredentialProvider)
 
     fp = FOPEN((PCHAR) pFileCredentialProvider->credentialsFilepath, "r");
 
-    CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
+    CHK(fp != NULL, STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED);
 
     // Get the size of the file
     FSEEK(fp, 0, SEEK_END);
@@ -146,7 +146,7 @@ STATUS readFileCredentials(PFileCredentialProvider pFileCredentialProvider)
 
     DLOGV("Reading AWS credentials from file: %s, file length = %" PRIu64 ".", pFileCredentialProvider->credentialsFilepath, fileLen);
 
-    CHK(fileLen < MAX_CREDENTIAL_FILE_LEN, STATUS_INVALID_ARG);
+    CHK(fileLen < MAX_CREDENTIAL_FILE_LEN, STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH);
 
     FSEEK(fp, 0, SEEK_SET);
 
@@ -176,7 +176,7 @@ STATUS readFileCredentials(PFileCredentialProvider pFileCredentialProvider)
         secretKey = fourthTokenStr;
     }
 
-    CHK(STRCMP(credentialMarker, "CREDENTIALS") == 0 , STATUS_INVALID_ARG);
+    CHK(STRCMP(credentialMarker, "CREDENTIALS") == 0 , STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT);
 
     // Set the lengths
     accessKeyIdLen = (UINT32) STRNLEN(accessKeyId, MAX_ACCESS_KEY_LEN);

--- a/tst/CallbacksProviderPublicApiTest.cpp
+++ b/tst/CallbacksProviderPublicApiTest.cpp
@@ -393,11 +393,12 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithFileAut
 {
     PClientCallbacks pClientCallbacks = NULL;
     CHAR filePath[MAX_PATH_LEN + 2];
+    CHAR fileContent[MAX_CREDENTIAL_FILE_LEN];
 
     MEMSET(filePath, 'a', ARRAY_SIZE(filePath));
     filePath[MAX_PATH_LEN + 1] = '\0';
 
-    EXPECT_EQ(STATUS_OPEN_FILE_FAILED, createDefaultCallbacksProviderWithFileAuth(
+    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED, createDefaultCallbacksProviderWithFileAuth(
             TEST_AUTH_FILE_PATH,
             (PCHAR) DEFAULT_AWS_REGION,
             TEST_CA_CERT_PATH,
@@ -416,6 +417,34 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithFileAut
     EXPECT_EQ(NULL, pClientCallbacks);
 
     EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithFileAuth(
+            filePath,
+            (PCHAR) DEFAULT_AWS_REGION,
+            TEST_CA_CERT_PATH,
+            TEST_USER_AGENT_POSTFIX,
+            TEST_USER_AGENT,
+            &pClientCallbacks));
+    EXPECT_EQ(NULL, pClientCallbacks);
+
+    // Try max file length
+    STRCPY(filePath, "credsFile");
+    MEMSET(fileContent, 'a', ARRAY_SIZE(fileContent));
+    ASSERT_EQ(STATUS_SUCCESS, writeFile(filePath, FALSE, FALSE, (PBYTE) fileContent, ARRAY_SIZE(fileContent)));
+
+    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH, createDefaultCallbacksProviderWithFileAuth(
+            filePath,
+            (PCHAR) DEFAULT_AWS_REGION,
+            TEST_CA_CERT_PATH,
+            TEST_USER_AGENT_POSTFIX,
+            TEST_USER_AGENT,
+            &pClientCallbacks));
+    EXPECT_EQ(NULL, pClientCallbacks);
+
+    // Try bad content creds file
+    STRCPY(filePath, "credsFile");
+    STRCPY(fileContent, "Bad creds file");
+    ASSERT_EQ(STATUS_SUCCESS, writeFile(filePath, FALSE, FALSE, (PBYTE) fileContent, STRLEN(fileContent)));
+
+    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT, createDefaultCallbacksProviderWithFileAuth(
             filePath,
             (PCHAR) DEFAULT_AWS_REGION,
             TEST_CA_CERT_PATH,


### PR DESCRIPTION
This will warrant a minor version bump on the next release!


Issue #https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/478


*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
