### PR TITLE
Add mbedTLS support for common LWS

### DIFF
--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -12,6 +12,12 @@ else()
   set(LWS_WITH_SHARED 1)
 endif()
 
+if (USE_MBEDTLS)
+  set(LWS_WITH_MBEDTLS ON)
+else()
+  set(LWS_WITH_MBEDTLS OFF)
+endif()
+
 ExternalProject_Add(project_libwebsockets
     GIT_REPOSITORY    https://github.com/warmcat/libwebsockets.git
     GIT_TAG           v3.2.3
@@ -33,6 +39,7 @@ ExternalProject_Add(project_libwebsockets
         -DLWS_WITH_SHARED=${LWS_WITH_SHARED}
         -DLWS_STATIC_PIC=1
         -DLWS_WITH_ZLIB=0
+        -DLWS_WITH_MBEDTLS=${LWS_WITH_MBEDTLS}
 # enable for debug output        -DCMAKE_BUILD_TYPE=DEBUG
         -DOPENSSL_ROOT_DIR=${OPENSSL_DIR}
         BUILD_ALWAYS      TRUE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,9 @@ if(BUILD_DEPENDENCIES)
 
   if (BUILD_COMMON_LWS)
     set(BUILD_ARGS  -DBUILD_STATIC=${BUILD_STATIC}
-                    -DOPENSSL_DIR=${OPEN_SRC_INSTALL_PREFIX})
+                    -DOPENSSL_DIR=${OPEN_SRC_INSTALL_PREFIX}
+                    -DUSE_OPENSSL=${USE_OPENSSL}
+                    -DUSE_MBEDTLS=${USE_MBEDTLS})
     build_dependency(websockets ${BUILD_ARGS})
   endif()
 
@@ -222,8 +224,7 @@ if(BUILD_COMMON_LWS)
       "${CMAKE_CURRENT_BINARY_DIR}/libkvsCommonLws.pc" @ONLY)
 
     add_library(kvsCommonLws STATIC ${KVS_COMMON_SOURCE_FILES_BASE} ${KVS_COMMON_SOURCE_FILES_LWS})
-    # dont support websocket with mbedtls yet
-    target_compile_definitions(kvsCommonLws PRIVATE KVS_BUILD_WITH_LWS KVS_USE_OPENSSL)
+    target_compile_definitions(kvsCommonLws PRIVATE KVS_BUILD_WITH_LWS ${CPRODUCER_COMMON_TLS_OPTION})
     target_link_libraries(kvsCommonLws
             ${OPENSSL_CRYPTO_LIBRARY}
             ${OPENSSL_SSL_LIBRARY}


### PR DESCRIPTION
This is required to enable mbedTLS support for WebRTC SDK, https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/121.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
