### PR TITLE
Forward CMAKE_BUILD_TYPE to pic

### DIFF
--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -10,6 +10,8 @@ ExternalProject_Add(libkvspic-download
     	GIT_TAG           af2168f7c0334630cbc4a7d02c3171df737a30f8
     	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
+	CMAKE_ARGS
+	  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND     ""
 	INSTALL_COMMAND   ""

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -8,12 +8,16 @@ function(fetch_repo lib_name)
     return()
   endif()
 
+  # anything after lib_name(${ARGN}) are assumed to be arguments passed over to
+  # library building cmake.
+  set(build_args ${ARGN})
+
   # build library
   configure_file(
     ./CMake/Dependencies/lib${lib_name}-CMakeLists.txt
     ${DEPENDENCY_DOWNLOAD_PATH}/lib${lib_name}/CMakeLists.txt COPYONLY)
   execute_process(
-    COMMAND ${CMAKE_COMMAND}
+    COMMAND ${CMAKE_COMMAND} ${build_args}
             ${CMAKE_GENERATOR} .
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH}/lib${lib_name})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,8 @@ endif()
 
 # repos that we will build using add_subdirectory will be stored in this path
 set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
-fetch_repo(kvspic)
+set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+fetch_repo(kvspic ${BUILD_ARGS})
 add_subdirectory("${DEPENDENCY_DOWNLOAD_PATH}/libkvspic/kvspic-src")
 file(GLOB PIC_HEADERS "${pic_project_SOURCE_DIR}/src/*/include")
 include_directories("${PIC_HEADERS}")


### PR DESCRIPTION
This will allow to forward CMAKE_BUILD_TYPE from a higher level library, such as webrtc SDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
