### PR TITLE
Update PIC to include non-BSD strnstr

### DIFF
--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-    	GIT_TAG           9779db4b12d5dc47eff38354c5197418fd66141d
+    	GIT_TAG           f362b4083366df2e3b1f56a860bf7dd474912fbe
     	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS


### PR DESCRIPTION
non-BSD strnstr is necessary for https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/600.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
