### PR TITLE
older versions of cmake dont have CURL::libcurl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ if(BUILD_COMMON_CURL)
     target_link_libraries(kvsCommonCurl
             ${PRODUCER_CRYPTO_LIBRARY}
             kvspicUtils
-            CURL::libcurl)
+            ${CURL_LIBRARIES})
 
     install(
       TARGETS kvsCommonCurl


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
