### PR TITLE
Only needed by windows.

### DIFF
--- a/CMake/Dependencies/libcurl-CMakeLists.txt
+++ b/CMake/Dependencies/libcurl-CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_ARGS
 
 # By default use openssl
 if (USE_MBEDTLS)
-    set(CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_USE_MBEDTLS=1 -DCURL_STATIC_CRT=1)
+    set(CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_USE_MBEDTLS=1)
 endif()
 
 if (WIN32)


### PR DESCRIPTION
CURL_STATIC_CRT "Set to ON to build libcurl with static CRT on Windows (/MT)."
https://github.com/winlibs/cURL/blob/master/CMakeLists.txt#L78

Recreate https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/pull/133 under SDK account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
