### PR TITLE
Fix tsan issues

### DIFF
--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-    	GIT_TAG           76223690da1329d733309e2a52575d6a98a68981
+    	GIT_TAG           988b1ab392b50f0ad573cc1a7183299f08425597
     	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS


### PR DESCRIPTION
This doesn't address all the issues reported by TSAN but the ones addressed so far are:

(1) In getStreamingEndpointCachingCurl we were not checking if a mutex was locked before unlocking, check added.
(2) In T1 we call `createDeviceCurl` which grabs the `activeRequestsLock` then we call `createDeviceResultEvent` in PIC which calls `createDeviceResult` which acquired the client lock.  In T2 in `putFrame` we first acquire the stream lock, then the client lock.  Next we invoke the callback in producer-c `streamLatencyPressureFn` which eventually calls `getStreamingEndpointCurl` which now acquires the `activeRequestsLock`.  This could result in deadlock and was the *only* potential deadlock reported by TSAN.  I think we never hit this because no one uses create Device.  Nonetheless to remedy this I've removed the acquisition of `activeRequestsLock` by T1 in `createDeviceCurl`