### PR TITLE
Not purging the API cache on reset

### DIFF
--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -713,8 +713,10 @@ STATUS shutdownStreamCurl(UINT64 customData, STREAM_HANDLE streamHandle, BOOL re
     CHK_STATUS(curlApiCallbacksShutdownActiveUploads(pCurlApiCallbacks, streamHandle, INVALID_UPLOAD_HANDLE_VALUE,
                                                      CURL_API_CALLBACKS_SHUTDOWN_TIMEOUT, FALSE, FALSE));
 
-    // Clear out the cached endpoints
-    CHK_STATUS(curlApiCallbacksShutdownCachedEndpoints(pCurlApiCallbacks, streamHandle, TRUE));
+    // Clear out the cached endpoints only when not resetting
+    if (!resetStream) {
+        CHK_STATUS(curlApiCallbacksShutdownCachedEndpoints(pCurlApiCallbacks, streamHandle, TRUE));
+    }
 
     // at this point all remaining threads should not be blocked and reach termination shortly. Thus spin wait for it
     // to remove itself from the pActiveRequests hashtable and pActiveUploads list

--- a/tst/ProducerFunctionalityTest.cpp
+++ b/tst/ProducerFunctionalityTest.cpp
@@ -291,6 +291,141 @@ TEST_F(ProducerFunctionalityTest, create_client_repeated_create_stream_put_frame
         EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoStream(&streamHandle));
         mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
     }
+
+    EXPECT_EQ(FUNCTIONALITY_TEST_STRESS_TEST_ITERATION, mCurlDescribeStreamCount);
+    EXPECT_EQ(FUNCTIONALITY_TEST_STRESS_TEST_ITERATION, mCurlGetDataEndpointCount);
+}
+
+TEST_F(ProducerFunctionalityTest, create_caching_endpoint_repeated_create_stream_put_frame_free_stream)
+{
+    UINT32 i, j;
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+    UINT32 totalFragments = 2;
+    UINT32 totalFrames = totalFragments * TEST_FPS;
+
+    createDefaultProducerClient(TRUE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
+
+    for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
+
+        EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
+        streamHandle = mStreams[0];
+        EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
+
+        for (j = 0; j < totalFrames; ++j) {
+            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
+            updateFrame();
+        }
+
+        mFrame.flags = FRAME_FLAG_NONE;
+        mFrame.presentationTs = 0;
+        mFrame.decodingTs = 0;
+        mFrame.index = 0;
+
+        EXPECT_EQ(STATUS_SUCCESS, stopKinesisVideoStreamSync(streamHandle));
+        EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoStream(&streamHandle));
+        mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
+    }
+
+    EXPECT_EQ(0, mCurlDescribeStreamCount);
+    EXPECT_EQ(FUNCTIONALITY_TEST_STRESS_TEST_ITERATION, mCurlGetDataEndpointCount);
+}
+
+TEST_F(ProducerFunctionalityTest, create_caching_endpoint_client_repeated_create_stream_put_frame_reset_stream)
+{
+    UINT32 i, j;
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+    UINT32 totalFragments = 2;
+    UINT32 totalFrames = totalFragments * TEST_FPS;
+
+    createDefaultProducerClient(TRUE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
+
+    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
+    streamHandle = mStreams[0];
+    EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
+
+    for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
+        for (j = 0; j < totalFrames; ++j) {
+            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
+            updateFrame();
+        }
+
+        mFrame.flags = FRAME_FLAG_NONE;
+        mFrame.presentationTs = 0;
+        mFrame.decodingTs = 0;
+        mFrame.index = 0;
+
+        EXPECT_EQ(STATUS_SUCCESS, stopKinesisVideoStreamSync(streamHandle));
+        EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamResetStream(streamHandle));
+    }
+
+    EXPECT_EQ(0, mCurlDescribeStreamCount);
+    EXPECT_EQ(1, mCurlGetDataEndpointCount);
+}
+
+TEST_F(ProducerFunctionalityTest, create_caching_all_repeated_create_stream_put_frame_free_stream)
+{
+    UINT32 i, j;
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+    UINT32 totalFragments = 2;
+    UINT32 totalFrames = totalFragments * TEST_FPS;
+
+    createDefaultProducerClient(API_CALL_CACHE_TYPE_ALL, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
+
+    for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
+
+        EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
+        streamHandle = mStreams[0];
+        EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
+
+        for (j = 0; j < totalFrames; ++j) {
+            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
+            updateFrame();
+        }
+
+        mFrame.flags = FRAME_FLAG_NONE;
+        mFrame.presentationTs = 0;
+        mFrame.decodingTs = 0;
+        mFrame.index = 0;
+
+        EXPECT_EQ(STATUS_SUCCESS, stopKinesisVideoStreamSync(streamHandle));
+        EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoStream(&streamHandle));
+        mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
+    }
+
+    EXPECT_EQ(FUNCTIONALITY_TEST_STRESS_TEST_ITERATION, mCurlDescribeStreamCount);
+    EXPECT_EQ(FUNCTIONALITY_TEST_STRESS_TEST_ITERATION, mCurlGetDataEndpointCount);
+}
+
+TEST_F(ProducerFunctionalityTest, create_caching_all_client_repeated_create_stream_put_frame_reset_stream)
+{
+    UINT32 i, j;
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+    UINT32 totalFragments = 2;
+    UINT32 totalFrames = totalFragments * TEST_FPS;
+
+    createDefaultProducerClient(API_CALL_CACHE_TYPE_ALL, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
+
+    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
+    streamHandle = mStreams[0];
+    EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
+
+    for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
+        for (j = 0; j < totalFrames; ++j) {
+            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
+            updateFrame();
+        }
+
+        mFrame.flags = FRAME_FLAG_NONE;
+        mFrame.presentationTs = 0;
+        mFrame.decodingTs = 0;
+        mFrame.index = 0;
+
+        EXPECT_EQ(STATUS_SUCCESS, stopKinesisVideoStreamSync(streamHandle));
+        EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamResetStream(streamHandle));
+    }
+
+    EXPECT_EQ(1, mCurlDescribeStreamCount);
+    EXPECT_EQ(1, mCurlGetDataEndpointCount);
 }
 
 TEST_F(ProducerFunctionalityTest, create_client_repeated_create_stream_put_frame_free_stream_multi_stream)


### PR DESCRIPTION
*Issue #, if available:*

The API cache is getting purged when the stream is being reset. This is not the right behavior and the fix (along with validating unit test) is for the cases when the application can stream, reset the stream, stream again and not call the APIs but rather use the cached value.

Currently, there are 3 types of caching defined

* none - no API caching is done
* Endpoing - all APIs will be always emulated with the exception of GetDataEndpoint which will be called once and the result cached
* All - all of the APIs will be called once and the result will be cached (except Create which can't be emulated)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
