### PR TITLE
wait a little bit for data before going into curl pause

### DIFF
--- a/src/source/Response.h
+++ b/src/source/Response.h
@@ -25,6 +25,11 @@ extern "C" {
 // Debug dump data file environment variable
 #define KVS_DEBUG_DUMP_DATA_FILE_DIR_ENV_VAR "KVS_DEBUG_DUMP_DATA_FILE_DIR"
 
+// this is used by postReadCallback to sleep before checking for more data
+#define MAX_GET_DATA_ITER 6
+
+#define BASE_GET_DATA_SLEEP_TIME (20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+
 /**
  * CURL callback function definitions
  */


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/490

*Description of changes:*

In the post read callback if I don't have data right away, I sleep and try again for 6 iterations with sleep [20 40 80 160 320] ms. My initial tests show this yields significant savings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
