### PR TITLE
There are 2 potential blocking calls when using IoTCredentialProvider…

### DIFF
--- a/src/source/Common/Lws/LwsCall.c
+++ b/src/source/Common/Lws/LwsCall.c
@@ -73,9 +73,13 @@ STATUS blockingLwsCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
 
 CleanUp:
 
-    if(retStatus == STATUS_IOT_CREATE_LWS_CONEXT_FAILED)
+    if(retStatus == STATUS_IOT_CREATE_LWS_CONTEXT_FAILED)
     {
-        DLOGW("Unable to create context or connect to websocket server");
+        DLOGW("Unable to create LWS context or connect to Websocket server");
+    }
+    else
+    {
+        CHK_LOG_ERR(retStatus);
     }
     if (lwsContext != NULL) {
         // Trigger termination

--- a/src/source/Common/Lws/LwsCall.c
+++ b/src/source/Common/Lws/LwsCall.c
@@ -73,6 +73,10 @@ STATUS blockingLwsCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
 
 CleanUp:
 
+    if(retStatus == STATUS_IOT_CREATE_LWS_CONEXT_FAILED)
+    {
+        DLOGW("Unable to create context or connect to websocket server");
+    }
     if (lwsContext != NULL) {
         // Trigger termination
         ATOMIC_STORE_BOOL(&pCallInfo->pRequestInfo->terminating, TRUE);


### PR DESCRIPTION
…: Curl & Lws.

The curl call already has logging when the curl_easy_perform fails, however the LWS blocking call did not have any logging on failure.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
