### PR TITLE
Check system for kvspic before doing git checkout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ if(KVSPIC_FOUND)
   link_directories(${KVSPIC_LIBRARY_DIRS})
 else()
   ############# fetch repos that we need do add_subdirectory ############
-
   # repos that we will build using add_subdirectory will be stored in this path
   set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
   set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,22 +93,33 @@ if(BUILD_DEPENDENCIES)
   message(STATUS "Finished building dependencies.")
 endif()
 
-############# fetch repos that we need do add_subdirectory ############
+find_package(PkgConfig REQUIRED)
 
-# repos that we will build using add_subdirectory will be stored in this path
-set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
-set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
-fetch_repo(kvspic ${BUILD_ARGS})
-add_subdirectory("${DEPENDENCY_DOWNLOAD_PATH}/libkvspic/kvspic-src")
-file(GLOB PIC_HEADERS "${pic_project_SOURCE_DIR}/src/*/include")
-include_directories("${PIC_HEADERS}")
+############# Check system for kvspic #############
 
-############# fetch repos that we need do add_subdirectory done ############
+pkg_check_modules(KVSPIC libkvspicUtils)
+if(KVSPIC_FOUND)
+  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${KVSPIC_INCLUDE_DIRS})
+  link_directories(${KVSPIC_LIBRARY_DIRS})
+else()
+  ############# fetch repos that we need do add_subdirectory ############
+
+  # repos that we will build using add_subdirectory will be stored in this path
+  set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
+  set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+  fetch_repo(kvspic ${BUILD_ARGS})
+  add_subdirectory("${DEPENDENCY_DOWNLOAD_PATH}/libkvspic/kvspic-src")
+  file(GLOB PIC_HEADERS "${pic_project_SOURCE_DIR}/src/*/include")
+  include_directories("${PIC_HEADERS}")
+
+  ############# fetch repos that we need do add_subdirectory done ############
+endif()
+
+############# Check system for kvspic done #############
 
 ############# find dependent libraries ############
 
 find_package(Threads)
-find_package(PkgConfig REQUIRED)
 
 set(OPEN_SRC_INCLUDE_DIRS ${LIBKVSPIC_INCLUDE_DIRS})
 


### PR DESCRIPTION
*Description of changes:*
Currently, the CMakeLists.txt assumes that you do not have any of the kvspic libraries and does a git checkout of https://github.com/awslabs/amazon-kinesis-video-streams-pic in order to meet the required dependency. This makes producer-c much harder to package (e.g. RPM/DEB) as most distributions do not permit network access and this forced git call will fail.

This patch checks for the kvspic library dependency that producer-c cares about (libkvspicUtils) and uses it if found. A more specific check could be done here to ensure that the found library has the necessary functionality, but to be honest, it would be easier to use a proper versioning scheme for kvspic and just check for supported version.

If the kvspic library is not found, it falls back to doing the git checkout logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
