### PR TITLE
use correct install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 include(Utilities)
 project(KinesisVideoProducerC LANGUAGES C)
 
+include(GNUInstallDirs)
+
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
 option(BUILD_STATIC "Static build" OFF)
@@ -247,12 +249,12 @@ if(BUILD_COMMON_LWS)
 
     install(
       TARGETS kvsCommonLws
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib
-      RUNTIME DESTINATION bin)
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     install(
       FILES ${CMAKE_CURRENT_BINARY_DIR}/libkvsCommonLws.pc
-      DESTINATION lib/pkgconfig)
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
 if(BUILD_COMMON_CURL)
@@ -270,12 +272,12 @@ if(BUILD_COMMON_CURL)
 
     install(
       TARGETS kvsCommonCurl
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib
-      RUNTIME DESTINATION bin)
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     install(
       FILES ${CMAKE_CURRENT_BINARY_DIR}/libkvsCommonCurl.pc
-      DESTINATION lib/pkgconfig)
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
     configure_file(
       "${CMAKE_CURRENT_SOURCE_DIR}/libcproducer.pc.cmake"
@@ -295,12 +297,12 @@ if(BUILD_COMMON_CURL)
 
     install(
       TARGETS cproducer
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib
-      RUNTIME DESTINATION bin)
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     install(
       FILES ${CMAKE_CURRENT_BINARY_DIR}/libcproducer.pc
-      DESTINATION lib/pkgconfig)
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
     add_executable(kvsVideoOnlyStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsVideoOnlyStreamingSample.c)
     target_link_libraries(kvsVideoOnlyStreamingSample cproducer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(KinesisVideoProducerC LANGUAGES C)
 
 include(GNUInstallDirs)
 
+
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
 option(BUILD_STATIC "Static build" OFF)

--- a/libcproducer.pc.cmake
+++ b/libcproducer.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: KVS-libcproducer
 Description: KVS C Producer library

--- a/libkvsCommonCurl.pc.cmake
+++ b/libkvsCommonCurl.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: KVS-libkvsCommonCurl
 Description: KVS C Producer common curl library

--- a/libkvsCommonLws.pc.cmake
+++ b/libkvsCommonLws.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: KVS-libkvsCommonLws
 Description: KVS C Producer common libwebsockets library


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As is, this software does not install properly on Red Hat based systems because it has "lib" hardcoded throughout. This pull request adjusts the cmake tooling to use GNUInstallDirs (and the associated CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_BINDIR) variables. The .pc.in files are also updated to use these variables.

With this change, files are installed into the proper locations on Fedora/Red Hat Enterprise Linux/CentOS/Amazon Linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
