### PR TITLE
Fix ubuntu build for v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,8 @@ if(BUILD_COMMON_CURL)
     else()
       add_library(cproducer ${TYPE_OF_LIB} ${PRODUCER_C_SOURCE_FILES})
     endif()
-    target_link_libraries(cproducer PUBLIC kvsCommonCurl ${CFLIBRARY} kvspic ${AWS_C_COMMON_LIBRARY})
+    #m needs to be linked for math library otherwise build fails in linux with undefined reference
+    target_link_libraries(cproducer PUBLIC kvsCommonCurl ${CFLIBRARY} kvspic ${AWS_C_COMMON_LIBRARY} m)
 
     install(
       TARGETS cproducer


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since AWS C Common relies on math.h in allocator, we need to link the math library as well with cproducer library. Without this, build on Linux fails with `undefined reference to 'round'` error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
