### PR TITLE
Fix CI cross compile file checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64
           make
-          file libKinesisVideoProducer.so
+          file libcproducer.so
   linux-aarch64-cross-compilation:
     runs-on: ubuntu-latest
     env:
@@ -330,7 +330,7 @@ jobs:
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64
           make
-          file libKinesisVideoProducer.so
+          file libcproducer.so
   arm32-cross-compilation:
     runs-on: ubuntu-latest
     env:
@@ -349,6 +349,6 @@ jobs:
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32
           make
-          file libKinesisVideoProducer.so
+          file libcproducer.so
 
           


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

CI cross compilation is wrongly trying to do file checks on .so file instead of .a.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
