### PR TITLE
Update Include.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ else()
 endif()
 
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU|Clang")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Werror=macro-redefined")
 
     if(ADD_MUCLIBC)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -muclibc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ else()
 endif()
 
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU|Clang")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Werror=macro-redefined")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
     if(ADD_MUCLIBC)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -muclibc")

--- a/src/include/com/amazonaws/kinesis/video/common/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/common/Include.h
@@ -50,22 +50,8 @@ extern "C" {
 #define STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED    STATUS_COMMON_PRODUCER_BASE + 0x00000022
 #define STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH STATUS_COMMON_PRODUCER_BASE + 0x00000023
 #define STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT STATUS_COMMON_PRODUCER_BASE + 0x00000024
-#define STATUS_CURL_PERFORM_FAILED                          STATUS_COMMON_PRODUCER_BASE + 0x00000025
-#define STATUS_IOT_INVALID_RESPONSE_LENGTH                  STATUS_COMMON_PRODUCER_BASE + 0x00000026
-#define STATUS_IOT_NULL_AWS_CREDS                           STATUS_COMMON_PRODUCER_BASE + 0x00000027
-#define STATUS_IOT_INVALID_URI_LEN                          STATUS_COMMON_PRODUCER_BASE + 0x00000028
 /*!@} */
 
-/**
- * Macro for checking whether the status code should be retried by the continuous retry logic
- */
-#define IS_RETRIABLE_COMMON_LIB_ERROR(error)                                                                                                         \
-    ((error) == STATUS_INVALID_API_CALL_RETURN_JSON || (error) == STATUS_CURL_INIT_FAILED || (error) == STATUS_CURL_LIBRARY_INIT_FAILED ||           \
-     (error) == STATUS_HMAC_GENERATION_ERROR || (error) == STATUS_CURL_PERFORM_FAILED || (error) == STATUS_IOT_INVALID_RESPONSE_LENGTH ||            \
-     (error) == STATUS_IOT_NULL_AWS_CREDS || (error) == STATUS_IOT_INVALID_URI_LEN || (error) == STATUS_IOT_EXPIRATION_OCCURS_IN_PAST ||                   \
-     (error) == STATUS_IOT_EXPIRATION_PARSING_FAILED || (error) == STATUS_IOT_CREATE_LWS_CONTEXT_FAILED ||                                           \
-     (error) == STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED || (error) == STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH ||                \
-     (error) == STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT)
 
 ////////////////////////////////////////////////////
 /// New common base status code.
@@ -88,6 +74,18 @@ extern "C" {
 #define STATUS_TIMESTAMP_STRING_UNRECOGNIZED_FORMAT     STATUS_COMMON_BASE + 0x00000005
 /*!@} */
 
+/**
+ * Macro for checking whether the status code should be retried by the continuous retry logic
+ */
+#define IS_RETRIABLE_COMMON_LIB_ERROR(error)                                                                                                         \
+    ((error) == STATUS_INVALID_API_CALL_RETURN_JSON || (error) == STATUS_CURL_INIT_FAILED || (error) == STATUS_CURL_LIBRARY_INIT_FAILED ||           \
+     (error) == STATUS_HMAC_GENERATION_ERROR || (error) == STATUS_CURL_PERFORM_FAILED || (error) == STATUS_IOT_INVALID_RESPONSE_LENGTH ||            \
+     (error) == STATUS_IOT_NULL_AWS_CREDS || (error) == STATUS_IOT_INVALID_URI_LEN || (error) == STATUS_IOT_EXPIRATION_OCCURS_IN_PAST ||                   \
+     (error) == STATUS_IOT_EXPIRATION_PARSING_FAILED || (error) == STATUS_IOT_CREATE_LWS_CONTEXT_FAILED ||                                           \
+     (error) == STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED || (error) == STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH ||                \
+     (error) == STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT)
+    
+    
 /////////////////////////////////////////////////////
 /// Lengths of different character arrays
 /////////////////////////////////////////////////////


### PR DESCRIPTION
define error codes only once
add flag to fail on macro redefine warning

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
