### PR TITLE
add support for CN region

### DIFF
--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -82,6 +82,10 @@ STATUS createCurlApiCallbacks(PCallbacksProvider pCallbacksProvider, PCHAR regio
         // Create a fully qualified URI
         SNPRINTF(pCurlApiCallbacks->controlPlaneUrl, MAX_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
                  pCurlApiCallbacks->region, CONTROL_PLANE_URI_POSTFIX);
+        // If region is in CN, add CN region uri postfix
+        if (STRSTR(pCurlApiCallbacks->region, "cn-")) {
+            STRCAT(pCurlApiCallbacks->controlPlaneUrl, ".cn");
+        }
     } else {
         STRNCPY(pCurlApiCallbacks->controlPlaneUrl, controlPlaneUrl, MAX_URI_CHAR_LEN);
     }


### PR DESCRIPTION
Signed-off-by: Alex Li <zhiqinli@amazon.com>

*Issue #, if available:*
KVS is now available in [China region](https://www.amazonaws.cn/en/new/2023/amazon-kinesis-video-streams-is--available-in-the-amazon-web-services-china-beijing-region-operated-by-sinnet/?nc1=h_ls)

In China region, all API endpoint will have postfix ".amazonaws.com.cn" instead of ".amazonaws.com". Use current SDK will cause DNS resolving error when call APIs in KVS control plane. Similar issue can be observed in WebRTC SDK as well.

*Description of changes:*
This commit will generate correct `controlPlaneUrl` according to configured region. Similar changes will be added into WebRTC SDK later on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
