### PR TITLE
Add new APIs to allow setting curl call timeouts

### DIFF
--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           75d917cd6e0eb1e846f08a629dafd02c259e9527
+	GIT_TAG           set-service-timeouts
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           set-service-timeouts
+	GIT_TAG           532178bbd4d2e6e6511fa8ffa62a15dba58c02f0
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/samples/KvsAudioOnlyStreamingSample.c
+++ b/samples/KvsAudioOnlyStreamingSample.c
@@ -54,7 +54,7 @@ PVOID putAudioFrameRoutine(PVOID args)
     frame.index = 0;
     frame.flags = fileIndex % DEFAULT_KEY_FRAME_INTERVAL == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
 
-    while (defaultGetTime() < data->streamStopTime) {
+    while (GETTIME() < data->streamStopTime) {
         status = putKinesisVideoFrame(data->streamHandle, &frame);            
         if (STATUS_FAILED(status)) {
             printf("putKinesisVideoFrame for audio failed with 0x%08x\n", status);
@@ -71,7 +71,7 @@ PVOID putAudioFrameRoutine(PVOID args)
         frame.size = data->audioFrames[fileIndex].size;
 
         // synchronize putKinesisVideoFrame to running time
-        runningTime = defaultGetTime() - data->streamStartTime;
+        runningTime = GETTIME() - data->streamStartTime;
         if (runningTime < frame.presentationTs) {
             THREAD_SLEEP(frame.presentationTs - runningTime);
         }
@@ -160,7 +160,7 @@ INT32 main(INT32 argc, CHAR* argv[])
         streamingDuration *= HUNDREDS_OF_NANOS_IN_A_SECOND;
     }
 
-    streamStopTime = defaultGetTime() + streamingDuration;
+    streamStopTime = GETTIME() + streamingDuration;
 
     // default storage size is 128MB. Use setDeviceInfoStorageSize after create to change storage size.
     CHK_STATUS(createDefaultDeviceInfo(&pDeviceInfo));
@@ -218,7 +218,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     data.streamStopTime = streamStopTime;
     data.streamHandle = streamHandle;
-    data.streamStartTime = defaultGetTime();
+    data.streamStartTime = GETTIME();
 
     THREAD_CREATE(&audioSendTid, putAudioFrameRoutine, (PVOID) &data);
 

--- a/samples/KvsVideoOnlyStreamingSample.c
+++ b/samples/KvsVideoOnlyStreamingSample.c
@@ -36,7 +36,7 @@ STATUS readFrameData(PFrame pFrame, PCHAR frameFilePath, PCHAR videoCodec)
     pFrame->size = (UINT32) size;
 
     if (pFrame->flags == FRAME_FLAG_KEY_FRAME) {
-        defaultLogPrint(LOG_LEVEL_DEBUG, "", "Key frame file %s, size %" PRIu64, filePath, pFrame->size);
+        DLOGD("Key frame file %s, size %" PRIu64, filePath, pFrame->size);
     }
 
 CleanUp:
@@ -70,15 +70,14 @@ INT32 main(INT32 argc, CHAR* argv[])
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
 
     if (argc < 2) {
-        defaultLogPrint(
-            LOG_LEVEL_ERROR, "",
+        DLOGE(
             "Usage: AWS_ACCESS_KEY_ID=SAMPLEKEY AWS_SECRET_ACCESS_KEY=SAMPLESECRET %s <stream_name> <duration_in_seconds> <frame_files_path>\n",
             argv[0]);
         CHK(FALSE, STATUS_INVALID_ARG);
     }
 
     if ((accessKey = getenv(ACCESS_KEY_ENV_VAR)) == NULL || (secretKey = getenv(SECRET_KEY_ENV_VAR)) == NULL) {
-        defaultLogPrint(LOG_LEVEL_ERROR, "", "Error missing credentials");
+        DLOGE("Error missing credentials");
         CHK(FALSE, STATUS_INVALID_ARG);
     }
 
@@ -109,7 +108,7 @@ INT32 main(INT32 argc, CHAR* argv[])
         streamingDuration *= HUNDREDS_OF_NANOS_IN_A_SECOND;
     }
 
-    streamStopTime = defaultGetTime() + streamingDuration;
+    streamStopTime = GETTIME() + streamingDuration;
 
     // default storage size is 128MB. Use setDeviceInfoStorageSize after create to change storage size.
     CHK_STATUS(createDefaultDeviceInfo(&pDeviceInfo));
@@ -145,10 +144,10 @@ INT32 main(INT32 argc, CHAR* argv[])
     frame.version = FRAME_CURRENT_VERSION;
     frame.trackId = DEFAULT_VIDEO_TRACK_ID;
     frame.duration = HUNDREDS_OF_NANOS_IN_A_SECOND / DEFAULT_FPS_VALUE;
-    frame.decodingTs = defaultGetTime(); // current time
+    frame.decodingTs = GETTIME(); // current time
     frame.presentationTs = frame.decodingTs;
 
-    while (defaultGetTime() < streamStopTime) {
+    while (GETTIME() < streamStopTime) {
         frame.index = frameIndex;
         frame.flags = fileIndex % DEFAULT_KEY_FRAME_INTERVAL == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
         frame.size = SIZEOF(frameBuffer);
@@ -177,7 +176,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 CleanUp:
 
     if (STATUS_FAILED(retStatus)) {
-        defaultLogPrint(LOG_LEVEL_ERROR, "", "Failed with status 0x%08x\n", retStatus);
+        DLOGE("Failed with status 0x%08x", retStatus);
     }
 
     if (pDeviceInfo != NULL) {

--- a/src/include/com/amazonaws/kinesis/video/common/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/common/Include.h
@@ -644,6 +644,26 @@ PUBLIC_API STATUS createLwsIotCredentialProvider(PCHAR, PCHAR, PCHAR, PCHAR, PCH
  * @param[in] PCHAR CA cert file path
  * @param[in] PCHAR Role alias
  * @param[in] PCHAR IoT thing name
+ * @param[in] UINT64 connection timeout
+ * @param[in] UINT64 completion timeout
+ * @param[in] GetCurrentTimeFunc Custom current time function
+ * @param[in] UINT64 Time function custom data
+ * @param[out] PAwsCredentialProvider* Constructed AWS credentials provider object
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS createCurlIotCredentialProviderWithTimeAndTimeout(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, UINT64, UINT64, GetCurrentTimeFunc, UINT64,
+                                                          PAwsCredentialProvider*);
+
+/**
+ * @brief Creates an IoT based AWS credential provider object with time function which is based on libCurl
+ *
+ * @param[in] PCHAR IoT endpoint
+ * @param[in] PCHAR Cert file path
+ * @param[in] PCHAR Private key file path
+ * @param[in] PCHAR CA cert file path
+ * @param[in] PCHAR Role alias
+ * @param[in] PCHAR IoT thing name
  * @param[in] GetCurrentTimeFunc Custom current time function
  * @param[in] UINT64 Time function custom data
  * @param[out] PAwsCredentialProvider* Constructed AWS credentials provider object
@@ -651,7 +671,7 @@ PUBLIC_API STATUS createLwsIotCredentialProvider(PCHAR, PCHAR, PCHAR, PCHAR, PCH
  * @return STATUS code of the execution. STATUS_SUCCESS on success
  */
 PUBLIC_API STATUS createCurlIotCredentialProviderWithTime(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, GetCurrentTimeFunc, UINT64,
-                                                          PAwsCredentialProvider*);
+        PAwsCredentialProvider*);
 
 /**
  * @brief Creates an IoT based AWS credential provider object with time function which is based on libWebSockets

--- a/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
@@ -343,6 +343,29 @@ PUBLIC_API STATUS createDefaultCallbacksProviderWithAwsCredentials(PCHAR, PCHAR,
 PUBLIC_API STATUS createDefaultCallbacksProviderWithIotCertificate(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PClientCallbacks*);
 
 /**
+ * Creates a default callbacks provider that uses iot certificate as auth method.
+ *
+ * NOTE: The caller is responsible for releasing the structure by calling
+ * the corresponding {@link freeCallbackProvider} API.
+ *
+ * @param[in] PCHAR IoT endpoint to use for the auth
+ * @param[in] PCHAR Credential cert path
+ * @param[in] PCHAR Private key path
+ * @param[in,opt] PCHAR CA Cert path
+ * @param[in] PCHAR Role alias name
+ * @param[in] PCHAR IoT Thing name
+ * @param[in,opt] PCHAR AWS region
+ * @param[in,opt] PCHAR User agent name (Use NULL)
+ * @param[in,opt] PCHAR Custom user agent to be used in the API calls
+ * @param[in] UINT64 connection timeout
+ * @param[in] UINT64 completion timeout
+ * @param[out] PClientCallbacks* Returned pointer to callbacks provider
+ *
+ * @return STATUS code of the execution
+ */
+PUBLIC_API STATUS createDefaultCallbacksProviderWithIotCertificateAndTimeouts(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, UINT64, UINT64, PClientCallbacks*);
+
+/**
  * Creates a default callbacks provider that uses file-based certificate as auth method.
  *
  * NOTE: The caller is responsible for releasing the structure by calling
@@ -688,6 +711,28 @@ PUBLIC_API STATUS setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(PDevic
  * @return STATUS status of operation
  */
 PUBLIC_API STATUS createIotAuthCallbacks(PClientCallbacks, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PAuthCallbacks*);
+
+/**
+ * Creates the Iot Credentials auth callbacks
+ *
+ * NOTE: The caller is responsible for releasing the structure by calling
+ * the corresponding free API.
+ *
+ * @param[in] PCallbacksProvider Pointer to callback provider
+ * @param[in] PCHAR iot credentials endpoint
+ * @param[in] PCHAR kvs iot certificate file path
+ * @param[in] PCHAR private key file path
+ * @param[in] PCHAR CA cert path
+ * @param[in] PCHAR iot role alias
+ * @param[in] PCHAR IoT thing name
+ * @param[in] UINT64 connection timeout
+ * @param[in] UINT64 completion timeout
+ *
+ * @param[in,out] PAuthCallbacks* Pointer to pointer to AuthCallback struct
+ *
+ * @return STATUS status of operation
+ */
+PUBLIC_API STATUS createIotAuthCallbacksWithTimeouts(PClientCallbacks, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, UINT64, UINT64, PAuthCallbacks*);
 
 /**
  * Frees the Iot Credential auth callbacks

--- a/src/source/CallbacksProvider.c
+++ b/src/source/CallbacksProvider.c
@@ -156,6 +156,53 @@ CleanUp:
     return retStatus;
 }
 
+STATUS createDefaultCallbacksProviderWithIotCertificateAndTimeouts(PCHAR endpoint, PCHAR iotCertPath, PCHAR privateKeyPath, PCHAR caCertPath, PCHAR roleAlias,
+                                                        PCHAR streamName, PCHAR region, PCHAR userAgentPostfix, PCHAR customUserAgent, UINT64 connectionTimeout,
+                                                        UINT64 completionTimeout, PClientCallbacks* ppClientCallbacks)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PCallbacksProvider pCallbacksProvider = NULL;
+    PAuthCallbacks pAuthCallbacks = NULL;
+    PStreamCallbacks pStreamCallbacks = NULL;
+
+    CHK_STATUS(createAbstractDefaultCallbacksProvider(DEFAULT_CALLBACK_CHAIN_COUNT, API_CALL_CACHE_TYPE_ALL, ENDPOINT_UPDATE_PERIOD_SENTINEL_VALUE,
+                                                      region, EMPTY_STRING, caCertPath, userAgentPostfix, customUserAgent, ppClientCallbacks));
+
+    pCallbacksProvider = (PCallbacksProvider) *ppClientCallbacks;
+
+    CHK_STATUS(createIotAuthCallbacksWithTimeouts((PClientCallbacks) pCallbacksProvider, endpoint, iotCertPath, privateKeyPath, caCertPath, roleAlias,
+                                                  streamName, connectionTimeout, completionTimeout, &pAuthCallbacks));
+
+    CHK_STATUS(createContinuousRetryStreamCallbacks((PClientCallbacks) pCallbacksProvider, &pStreamCallbacks));
+
+    CleanUp:
+
+    if (STATUS_FAILED(retStatus)) {
+        if (pCallbacksProvider != NULL) {
+            freeCallbacksProvider((PClientCallbacks*) &pCallbacksProvider);
+        }
+
+        if (pAuthCallbacks != NULL) {
+            freeIotAuthCallbacks(&pAuthCallbacks);
+        }
+
+        if (pStreamCallbacks != NULL) {
+            freeContinuousRetryStreamCallbacks(&pStreamCallbacks);
+        }
+
+        pCallbacksProvider = NULL;
+    }
+
+    // Set the return value if it's not NULL
+    if (ppClientCallbacks != NULL) {
+        *ppClientCallbacks = (PClientCallbacks) pCallbacksProvider;
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS createDefaultCallbacksProviderWithFileAuth(PCHAR credentialsFilePath, PCHAR region, PCHAR caCertPath, PCHAR userAgentPostfix,
                                                   PCHAR customUserAgent, PClientCallbacks* ppClientCallbacks)
 {

--- a/src/source/Common/Curl/CurlCall.c
+++ b/src/source/Common/Curl/CurlCall.c
@@ -63,6 +63,7 @@ STATUS blockingCurlCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
     curl_easy_setopt(curl, CURLOPT_SSLKEY, pRequestInfo->sslPrivateKeyPath);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCurlResponseCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, pCallInfo);
+
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, pRequestInfo->connectionTimeout / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     if (pRequestInfo->completionTimeout != SERVICE_CALL_INFINITE_TIMEOUT) {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, pRequestInfo->completionTimeout / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);

--- a/src/source/Common/Curl/CurlIotCredentialProvider.c
+++ b/src/source/Common/Curl/CurlIotCredentialProvider.c
@@ -15,6 +15,14 @@ STATUS createCurlIotCredentialProviderWithTime(PCHAR iotGetCredentialEndpoint, P
                                                PCHAR roleAlias, PCHAR thingName, GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData,
                                                PAwsCredentialProvider* ppCredentialProvider)
 {
-    return createIotCredentialProviderWithTime(iotGetCredentialEndpoint, certPath, privateKeyPath, caCertPath, roleAlias, thingName, getCurrentTimeFn,
+    return createIotCredentialProviderWithTime(iotGetCredentialEndpoint, certPath, privateKeyPath, caCertPath, roleAlias, thingName, IOT_REQUEST_CONNECTION_TIMEOUT, IOT_REQUEST_COMPLETION_TIMEOUT, getCurrentTimeFn,
+                                               customData, blockingCurlCall, ppCredentialProvider);
+}
+
+STATUS createCurlIotCredentialProviderWithTimeAndTimeout(PCHAR iotGetCredentialEndpoint, PCHAR certPath, PCHAR privateKeyPath, PCHAR caCertPath,
+                                               PCHAR roleAlias, PCHAR thingName, UINT64 connectionTimeout, UINT64 completionTimeout, GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData,
+                                               PAwsCredentialProvider* ppCredentialProvider)
+{
+    return createIotCredentialProviderWithTime(iotGetCredentialEndpoint, certPath, privateKeyPath, caCertPath, roleAlias, thingName, connectionTimeout, completionTimeout, getCurrentTimeFn,
                                                customData, blockingCurlCall, ppCredentialProvider);
 }

--- a/src/source/Common/IotCredentialProvider.c
+++ b/src/source/Common/IotCredentialProvider.c
@@ -5,7 +5,7 @@
 #include "Include_i.h"
 
 STATUS createIotCredentialProviderWithTime(PCHAR iotGetCredentialEndpoint, PCHAR certPath, PCHAR privateKeyPath, PCHAR caCertPath, PCHAR roleAlias,
-                                           PCHAR thingName, GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData,
+                                           PCHAR thingName, UINT64 connectionTimeout, UINT64 completionTimeout, GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData,
                                            BlockingServiceCallFunc serviceCallFn, PAwsCredentialProvider* ppCredentialProvider)
 {
     ENTERS();
@@ -46,6 +46,21 @@ STATUS createIotCredentialProviderWithTime(PCHAR iotGetCredentialEndpoint, PCHAR
     STRNCPY(pIotCredentialProvider->thingName, thingName, MAX_IOT_THING_NAME_LEN);
 
     pIotCredentialProvider->serviceCallFn = serviceCallFn;
+
+    if(completionTimeout < connectionTimeout) {
+        DLOGW("Setting defaults for connection and completion timeout since completion timeout is less than connection timeout");
+        connectionTimeout = IOT_REQUEST_CONNECTION_TIMEOUT;
+        completionTimeout = IOT_REQUEST_COMPLETION_TIMEOUT;
+    }
+    if(connectionTimeout == 0) {
+        connectionTimeout = IOT_REQUEST_CONNECTION_TIMEOUT;
+    }
+    pIotCredentialProvider->connectionTimeout = connectionTimeout;
+
+    if(completionTimeout == 0) {
+        completionTimeout = IOT_REQUEST_COMPLETION_TIMEOUT;
+    }
+    pIotCredentialProvider->completionTimeout = completionTimeout;
 
     CHK_STATUS(iotCurlHandler(pIotCredentialProvider));
 
@@ -216,7 +231,7 @@ STATUS iotCurlHandler(PIotCredentialProvider pIotCredentialProvider)
     // Form a new request info based on the params
     CHK_STATUS(createRequestInfo(serviceUrl, NULL, DEFAULT_AWS_REGION, pIotCredentialProvider->caCertPath, pIotCredentialProvider->certPath,
                                  pIotCredentialProvider->privateKeyPath, SSL_CERTIFICATE_TYPE_PEM, DEFAULT_USER_AGENT_NAME,
-                                 IOT_REQUEST_CONNECTION_TIMEOUT, IOT_REQUEST_COMPLETION_TIMEOUT, DEFAULT_LOW_SPEED_LIMIT,
+                                 pIotCredentialProvider->connectionTimeout, pIotCredentialProvider->completionTimeout, DEFAULT_LOW_SPEED_LIMIT,
                                  DEFAULT_LOW_SPEED_TIME_LIMIT, pIotCredentialProvider->pAwsCredentials, &pRequestInfo));
 
     callInfo.pRequestInfo = pRequestInfo;

--- a/src/source/Common/IotCredentialProvider.h
+++ b/src/source/Common/IotCredentialProvider.h
@@ -54,6 +54,10 @@ struct __IotCredentialProvider {
     // String name is used as IoT thing-name
     CHAR thingName[MAX_STREAM_NAME_LEN + 1];
 
+    UINT64 connectionTimeout;
+
+    UINT64 completionTimeout;
+
     // Static Aws Credentials structure with the pointer following the main allocation
     PAwsCredentials pAwsCredentials;
 
@@ -65,7 +69,7 @@ typedef struct __IotCredentialProvider* PIotCredentialProvider;
 ////////////////////////////////////////////////////////////////////////
 // Callback function implementations
 ////////////////////////////////////////////////////////////////////////
-STATUS createIotCredentialProviderWithTime(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, GetCurrentTimeFunc, UINT64, BlockingServiceCallFunc,
+STATUS createIotCredentialProviderWithTime(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, UINT64, UINT64, GetCurrentTimeFunc, UINT64, BlockingServiceCallFunc,
                                            PAwsCredentialProvider*);
 STATUS getIotCredentials(PAwsCredentialProvider, PAwsCredentials*);
 

--- a/src/source/Common/Lws/LwsIotCredentialProvider.c
+++ b/src/source/Common/Lws/LwsIotCredentialProvider.c
@@ -15,6 +15,6 @@ STATUS createLwsIotCredentialProviderWithTime(PCHAR iotGetCredentialEndpoint, PC
                                               PCHAR thingName, GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData,
                                               PAwsCredentialProvider* ppCredentialProvider)
 {
-    return createIotCredentialProviderWithTime(iotGetCredentialEndpoint, certPath, privateKeyPath, caCertPath, roleAlias, thingName, getCurrentTimeFn,
+    return createIotCredentialProviderWithTime(iotGetCredentialEndpoint, certPath, privateKeyPath, caCertPath, roleAlias, thingName, 0, 0, getCurrentTimeFn,
                                                customData, blockingLwsCall, ppCredentialProvider);
 }

--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -73,7 +73,6 @@ STATUS createCurlApiCallbacks(PCallbacksProvider pCallbacksProvider, PCHAR regio
 
     status = getUserAgentString(userAgentNamePostfix, customUserAgent, MAX_USER_AGENT_LEN, pCurlApiCallbacks->userAgent);
     pCurlApiCallbacks->userAgent[MAX_USER_AGENT_LEN] = '\0';
-    printf("User agent name for curl calls: %s\n", pCurlApiCallbacks->userAgent);
     if (STATUS_FAILED(status)) {
         DLOGW("Failed to generate user agent string with error 0x%08x.", status);
     }

--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -73,6 +73,7 @@ STATUS createCurlApiCallbacks(PCallbacksProvider pCallbacksProvider, PCHAR regio
 
     status = getUserAgentString(userAgentNamePostfix, customUserAgent, MAX_USER_AGENT_LEN, pCurlApiCallbacks->userAgent);
     pCurlApiCallbacks->userAgent[MAX_USER_AGENT_LEN] = '\0';
+    printf("User agent name for curl calls: %s\n", pCurlApiCallbacks->userAgent);
     if (STATUS_FAILED(status)) {
         DLOGW("Failed to generate user agent string with error 0x%08x.", status);
     }
@@ -957,7 +958,7 @@ STATUS createStreamCurl(UINT64 customData, PCHAR deviceName, PCHAR streamName, P
     // Create a request object
     currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
     CHK_STATUS(createCurlRequest(HTTP_REQUEST_VERB_POST, url, paramsJson, streamHandle, pCurlApiCallbacks->region, currentTime,
-                                 CURL_API_DEFAULT_CONNECTION_TIMEOUT, pServiceCallContext->timeout, pServiceCallContext->callAfter,
+                                 pServiceCallContext->connectionTimeout, pServiceCallContext->timeout, pServiceCallContext->callAfter,
                                  pCurlApiCallbacks->certPath, pCredentials, pCurlApiCallbacks, &pCurlRequest));
 
     // Set the necessary headers
@@ -1190,7 +1191,7 @@ STATUS describeStreamCurl(UINT64 customData, PCHAR streamName, PServiceCallConte
     // Create a request object
     currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
     CHK_STATUS(createCurlRequest(HTTP_REQUEST_VERB_POST, url, paramsJson, streamHandle, pCurlApiCallbacks->region, currentTime,
-                                 CURL_API_DEFAULT_CONNECTION_TIMEOUT, pServiceCallContext->timeout, pServiceCallContext->callAfter,
+                                 pServiceCallContext->connectionTimeout, pServiceCallContext->timeout, pServiceCallContext->callAfter,
                                  pCurlApiCallbacks->certPath, pCredentials, pCurlApiCallbacks, &pCurlRequest));
 
     // Set the necessary headers
@@ -1498,7 +1499,7 @@ STATUS getStreamingEndpointCurl(UINT64 customData, PCHAR streamName, PCHAR apiNa
     // Create a request object
     currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
     CHK_STATUS(createCurlRequest(HTTP_REQUEST_VERB_POST, url, paramsJson, streamHandle, pCurlApiCallbacks->region, currentTime,
-                                 CURL_API_DEFAULT_CONNECTION_TIMEOUT, pServiceCallContext->timeout, pServiceCallContext->callAfter,
+                                 pServiceCallContext->connectionTimeout, pServiceCallContext->timeout, pServiceCallContext->callAfter,
                                  pCurlApiCallbacks->certPath, pCredentials, pCurlApiCallbacks, &pCurlRequest));
 
     // Set the necessary headers
@@ -1827,7 +1828,7 @@ STATUS tagResourceCurl(UINT64 customData, PCHAR streamArn, UINT32 tagCount, PTag
     // Create a request object
     currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
     CHK_STATUS(createCurlRequest(HTTP_REQUEST_VERB_POST, url, paramsJson, streamHandle, pCurlApiCallbacks->region, currentTime,
-                                 CURL_API_DEFAULT_CONNECTION_TIMEOUT, pServiceCallContext->timeout, pServiceCallContext->callAfter,
+                                 pServiceCallContext->connectionTimeout, pServiceCallContext->timeout, pServiceCallContext->callAfter,
                                  pCurlApiCallbacks->certPath, pCredentials, pCurlApiCallbacks, &pCurlRequest));
 
     // Set the necessary headers
@@ -2041,7 +2042,7 @@ STATUS putStreamCurl(UINT64 customData, PCHAR streamName, PCHAR containerType, U
     // Create a request object
     currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
     CHK_STATUS(createCurlRequest(HTTP_REQUEST_VERB_POST, url, NULL, (STREAM_HANDLE) pServiceCallContext->customData, pCurlApiCallbacks->region,
-                                 currentTime, CURL_API_DEFAULT_CONNECTION_TIMEOUT, pServiceCallContext->timeout, pServiceCallContext->callAfter,
+                                 currentTime, pServiceCallContext->connectionTimeout, pServiceCallContext->timeout, pServiceCallContext->callAfter,
                                  pCurlApiCallbacks->certPath, pCredentials, pCurlApiCallbacks, &pCurlRequest));
 
     // Set the necessary headers

--- a/src/source/IotAuthCallback.c
+++ b/src/source/IotAuthCallback.c
@@ -58,6 +58,61 @@ CleanUp:
     return retStatus;
 }
 
+/*
+ * Create IoT credentials callback
+ */
+STATUS createIotAuthCallbacksWithTimeouts(PClientCallbacks pCallbacksProvider, PCHAR iotGetCredentialEndpoint, PCHAR certPath, PCHAR privateKeyPath,
+                              PCHAR caCertPath, PCHAR roleAlias, PCHAR streamName, UINT64 connectionTimeout, UINT64 completionTimeout, PAuthCallbacks* ppIotAuthCallbacks)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    PIotAuthCallbacks pIotAuthCallbacks = NULL;
+
+    CHK(pCallbacksProvider != NULL && ppIotAuthCallbacks != NULL, STATUS_NULL_ARG);
+
+    // Allocate the entire structure
+    pIotAuthCallbacks = (PIotAuthCallbacks) MEMCALLOC(1, SIZEOF(IotAuthCallbacks));
+    CHK(pIotAuthCallbacks != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    // Set the version, self
+    pIotAuthCallbacks->authCallbacks.version = AUTH_CALLBACKS_CURRENT_VERSION;
+    pIotAuthCallbacks->authCallbacks.customData = (UINT64) pIotAuthCallbacks;
+
+    // Store the back pointer as we will be using the other callbacks
+    pIotAuthCallbacks->pCallbacksProvider = (PCallbacksProvider) pCallbacksProvider;
+
+    // Set the callbacks
+    pIotAuthCallbacks->authCallbacks.getStreamingTokenFn = getStreamingTokenIotFunc;
+    pIotAuthCallbacks->authCallbacks.getSecurityTokenFn = getSecurityTokenIotFunc;
+    pIotAuthCallbacks->authCallbacks.freeAuthCallbacksFn = freeIotAuthCallbacksFunc;
+    pIotAuthCallbacks->authCallbacks.getDeviceCertificateFn = NULL;
+    pIotAuthCallbacks->authCallbacks.deviceCertToTokenFn = NULL;
+    pIotAuthCallbacks->authCallbacks.getDeviceFingerprintFn = NULL;
+
+    CHK_STATUS(createCurlIotCredentialProviderWithTimeAndTimeout(iotGetCredentialEndpoint, certPath, privateKeyPath, caCertPath, roleAlias, streamName,
+                                                       connectionTimeout, completionTimeout,
+                                                       pIotAuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn,
+                                                       pIotAuthCallbacks->pCallbacksProvider->clientCallbacks.customData,
+                                                       (PAwsCredentialProvider*) &pIotAuthCallbacks->pCredentialProvider));
+
+    CHK_STATUS(addAuthCallbacks(pCallbacksProvider, (PAuthCallbacks) pIotAuthCallbacks));
+
+    CleanUp:
+
+    if (STATUS_FAILED(retStatus)) {
+        freeIotAuthCallbacks((PAuthCallbacks*) &pIotAuthCallbacks);
+        pIotAuthCallbacks = NULL;
+    }
+    // Set the return value if it's not NULL
+    if (ppIotAuthCallbacks != NULL) {
+        *ppIotAuthCallbacks = (PAuthCallbacks) pIotAuthCallbacks;
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
 /**
  * Frees the IotCredential Auth callback object
  *

--- a/tst/CallbacksProviderPublicApiTest.cpp
+++ b/tst/CallbacksProviderPublicApiTest.cpp
@@ -166,6 +166,193 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithIotCert
             &pClientCallbacks));
 }
 
+TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithIotCertificateAndTimeouts)
+{
+    PClientCallbacks pClientCallbacks;
+
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            TEST_USER_AGENT_POSTFIX,
+            TEST_USER_AGENT,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            NULL));
+
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            NULL,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            NULL,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            NULL,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            NULL,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_CA_CERT_PATH,
+            NULL,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            NULL,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            EMPTY_STRING,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            EMPTY_STRING,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            EMPTY_STRING,
+            TEST_CA_CERT_PATH,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+
+    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+            TEST_IOT_ENDPOINT,
+            TEST_IOT_CERT_PATH,
+            TEST_IOT_CERT_PRIVATE_KEY_PATH,
+            EMPTY_STRING,
+            TEST_IOT_ROLE_ALIAS,
+            TEST_IOT_THING_NAME,
+            (PCHAR) DEFAULT_AWS_REGION,
+            NULL,
+            NULL,
+            1,
+            2,
+            &pClientCallbacks));
+}
+
 TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAwsCredentials)
 {
     PClientCallbacks pClientCallbacks = NULL;

--- a/tst/FileLoggerFunctionalityTest.cpp
+++ b/tst/FileLoggerFunctionalityTest.cpp
@@ -111,7 +111,7 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video {
         // make sure the files dont exist
         FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
         for(; i < logIterationCount; ++i) {
-            SPRINTF(filePath, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
+            SNPRINTF(filePath, MAX_PATH_LEN, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
             FREMOVE(filePath);
         }
 
@@ -126,7 +126,7 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video {
         EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
         for(i = 0; i < logIterationCount; ++i) {
-            SPRINTF(filePath, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
+            SNPRINTF(filePath, MAX_PATH_LEN, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
             EXPECT_EQ(STATUS_SUCCESS, fileExists(filePath, &fileFound));
             // only log file with index from 6 to 11 should remain. The rest are rotated out.
             if (i < logIterationCount && i >= (logIterationCount - maxLogFileCount)) {

--- a/tst/ProducerClientBasicTest.cpp
+++ b/tst/ProducerClientBasicTest.cpp
@@ -133,7 +133,7 @@ PVOID ProducerClientBasicTest::staticCreateProducerClientRoutine(PVOID arg)
     streamInfo.streamCaps.trackInfoCount = 1;
     streamInfo.streamCaps.trackInfoList = &trackInfo;
     streamInfo.streamCaps.frameOrderingMode = FRAME_ORDER_MODE_PASS_THROUGH;
-    SPRINTF(streamInfo.name, "ScaryTestStream_%u", (UINT32) index);
+    SNPRINTF(streamInfo.name, MAX_STREAM_NAME_LEN + 1, "ScaryTestStream_%u", (UINT32) index);
 	
     EXPECT_EQ(STATUS_SUCCESS, retStatus = createKinesisVideoStreamSync(pTest->mClients[index], &streamInfo, &pTest->mStreams[index]));
 
@@ -192,7 +192,7 @@ PVOID ProducerClientBasicTest::staticCreateProducerRoutine(PVOID arg)
     streamInfo.streamCaps.trackInfoCount = 1;
     streamInfo.streamCaps.trackInfoList = &trackInfo;
     streamInfo.streamCaps.frameOrderingMode = FRAME_ORDER_MODE_PASS_THROUGH;
-    SPRINTF(streamInfo.name, "ScaryTestStream_%u", (UINT32) index);
+    SNPRINTF(streamInfo.name, MAX_STREAM_NAME_LEN + 1, "ScaryTestStream_%u", (UINT32) index);
 
     retStatus = createKinesisVideoStreamSync(pTest->mClientHandle, &streamInfo, &pTest->mStreams[index]);
 

--- a/tst/ProducerFunctionalityTest.cpp
+++ b/tst/ProducerFunctionalityTest.cpp
@@ -25,7 +25,7 @@ TEST_F(ProducerFunctionalityTest, create_stream_async_free_stress_test)
 {
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
     UINT32 i = 0, wait;
-    SPRINTF(mStreamInfo.name, "ScaryTestStream_%d", 0);
+    SNPRINTF(mStreamInfo.name, MAX_STREAM_NAME_LEN + 1, "ScaryTestStream_%d", 0);
 
     for (i = 0; i < 5; i++) {
         EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStream(mClientHandle, &mStreamInfo, &mStreams[0]));
@@ -44,7 +44,7 @@ TEST_F(ProducerFunctionalityTest, create_two_stream_async_free_stress_test)
 
     for (i = 0; i < 3; i++) {
         for (j = 0; j < totalStreams; j++) {
-            SPRINTF(mStreamInfo.name, "ScaryTestStream_%d", j);
+            SNPRINTF(mStreamInfo.name, MAX_STREAM_NAME_LEN + 1, "ScaryTestStream_%d", j);
             EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStream(mClientHandle, &mStreamInfo, &mStreams[j]));
         }
         wait = RAND() % 100;

--- a/tst/ProducerTestFixture.cpp
+++ b/tst/ProducerTestFixture.cpp
@@ -507,12 +507,12 @@ STATUS ProducerClientTestBase::createTestStream(UINT32 index, STREAMING_TYPE str
     for (UINT32 i = 0; i < tagCount; i++) {
         tags[i].name = (PCHAR) MEMALLOC(SIZEOF(CHAR) * (MAX_TAG_NAME_LEN + 1));
         tags[i].value = (PCHAR) MEMALLOC(SIZEOF(CHAR) * (MAX_TAG_VALUE_LEN + 1));
-        SPRINTF(tags[i].name, "testTag_%d_%d", index, i);
-        SPRINTF(tags[i].value, "testTag_%d_%d_Value", index, i);
+        SNPRINTF(tags[i].name, MAX_TAG_NAME_LEN, "testTag_%d_%d", index, i);
+        SNPRINTF(tags[i].value, MAX_TAG_VALUE_LEN, "testTag_%d_%d_Value", index, i);
         tags[i].version = TAG_CURRENT_VERSION;
     }
 
-    SPRINTF(mStreamInfo.name, "ScaryTestStream_%d", index);
+    SNPRINTF(mStreamInfo.name, MAX_STREAM_NAME_LEN + 1, "ScaryTestStream_%d", index);
     mStreamInfo.tagCount = tagCount;
     mStreamInfo.tags = tags;
     mStreamInfo.streamCaps.streamingType = streamingType;

--- a/tst/ProducerTestFixture.h
+++ b/tst/ProducerTestFixture.h
@@ -54,6 +54,7 @@
 
 #define TEST_IOT_ENDPOINT              (PCHAR) "Test.iot.endpoint"
 #define TEST_IOT_CERT_PATH             (PCHAR) "/Test/credentials/cert/path"
+#define TEST_IOT_VALID_CERT_PATH       (PCHAR) "../"
 #define TEST_IOT_CERT_PRIVATE_KEY_PATH (PCHAR) "/Test/private/key/path"
 #define TEST_CA_CERT_PATH              (PCHAR) "/Test/private/ca_cert/path"
 #define TEST_IOT_ROLE_ALIAS            (PCHAR) "TestRoleAlias"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- New APIs to allow setting timeouts for IoT curl calls. If either connection or completion timeouts are 0, defaults are set.
- Fix warning in samples


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
