### PR TITLE
Remove an extra newline in the logs

### DIFF
--- a/src/source/Common/Lws/LwsCall.c
+++ b/src/source/Common/Lws/LwsCall.c
@@ -185,7 +185,7 @@ INT32 lwsIotCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, P
             break;
 
         case LWS_CALLBACK_CLIENT_APPEND_HANDSHAKE_HEADER:
-            DLOGD("Client append handshake header\n");
+            DLOGD("Client append handshake header");
             CHK_STATUS(singleListGetNodeCount(pRequestInfo->pRequestHeaders, &headerCount));
             ppStartPtr = (PBYTE*) pDataIn;
             pEndPtr = *ppStartPtr + dataSize - 1;


### PR DESCRIPTION
There's an extra newline in the logs that doesn't need to be there