### PR TITLE
Update pic commit to include logging, images and couple of other fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           bash scripts/check-clang.sh
 
   mac-os-build-gcc:
-    runs-on: macos-11
+    runs-on: macos-13
     permissions:
       id-token: write
       contents: read
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build repository
         run: |
+          brew install pkgconfig
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE
           make
@@ -52,7 +53,7 @@ jobs:
           ./tst/producer_test
 
   mac-os-build-clang:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       AWS_KVS_LOG_LEVEL: 2
       LDFLAGS: -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
@@ -65,6 +66,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build repository
         run: |
+          brew install pkgconfig
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
           make
@@ -78,7 +80,7 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ./tst/producer_test --gtest_filter
+          ./tst/producer_test
 
   mac-os-build-gcc-local-openssl:
     runs-on: macos-11
@@ -89,12 +91,15 @@ jobs:
       CC: gcc
       CXX: g++
       AWS_KVS_LOG_LEVEL: 2
-      PKG_CONFIG_PATH: /usr/local/opt/openssl@1.1/lib/pkgconfig
+      LDFLAGS: -L/usr/local/opt/openssl@3/lib
+      CPPFLAGS: -I/usr/local/opt/openssl@3/include
+      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
       - name: Build repository
         run: |
+          brew info openssl
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DLOCAL_OPENSSL_BUILD=ON
           make
@@ -114,9 +119,9 @@ jobs:
     runs-on: macos-latest
     env:
       AWS_KVS_LOG_LEVEL: 2
-      LDFLAGS: -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
-      CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
-      PKG_CONFIG_PATH: /usr/local/opt/openssl@1.1/lib/pkgconfig
+      LDFLAGS: -L/usr/local/opt/openssl@3/lib
+      CPPFLAGS: -I/usr/local/opt/openssl@3/include
+      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
     permissions:
       id-token: write
       contents: read
@@ -125,6 +130,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build repository
         run: |
+          brew info openssl
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DLOCAL_OPENSSL_BUILD=ON
           make

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           532178bbd4d2e6e6511fa8ffa62a15dba58c02f0
+	GIT_TAG           7b7d9d126d9ef9d354f9218e4361f72adb0a8635
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
@@ -892,8 +892,23 @@ PUBLIC_API STATUS createAbstractDefaultCallbacksProvider(UINT32, API_CALL_CACHE_
  * @return STATUS code of the execution
  */
 PUBLIC_API STATUS addFileLoggerPlatformCallbacksProvider(PClientCallbacks, UINT64, UINT64, PCHAR, BOOL);
-/*!@} */
 
+/**
+ * Use file logger with level filtering instead of default logger which log to stdout. The underlying objects are automatically freed
+ * when PClientCallbacks is freed.
+ *
+ * @param[in] PClientCallbacks The callback provider whose logPrintFn will be replaced with file logger log printing function
+ * @param[in] UINT64 Size of string buffer in file logger. When the string buffer is full the logger will flush everything into a new file
+ * @param[in] UINT64 Max number of log file. When exceeded, the oldest file will be deleted when new one is generated
+ * @param[in] PCHAR Directory in which the log file will be generated
+ * @param[in] BOOL Enable logging other log levels into a file
+ * @param[in] UINT32 Log level that needs to be filtered into another file
+ * @param[in] BOOL print log to std out too
+ *
+ * @return STATUS code of the execution
+ */
+STATUS addFileLoggerWithFilteringPlatformCallbacksProvider(PClientCallbacks, UINT64, UINT64, PCHAR, BOOL, BOOL, UINT32);
+/*!@} */
 #ifdef __cplusplus
 }
 #endif

--- a/src/source/FileLoggerPlatformCallbackProvider.c
+++ b/src/source/FileLoggerPlatformCallbackProvider.c
@@ -48,3 +48,36 @@ CleanUp:
     }
     return retStatus;
 }
+
+STATUS addFileLoggerWithFilteringPlatformCallbacksProvider(PClientCallbacks pClientCallbacks, UINT64 stringBufferSize, UINT64 maxLogFileCount, PCHAR logFileDir,
+                                              BOOL printLog, BOOL enableAllLevels, UINT32 level)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PCallbacksProvider pCallbackProvider = (PCallbacksProvider) pClientCallbacks;
+    PlatformCallbacks fileLoggerPlatformCallbacks;
+    logPrintFunc logFn;
+
+    CHK(pCallbackProvider != NULL, STATUS_NULL_ARG);
+
+    CHK_STATUS(createFileLoggerWithLevelFiltering(stringBufferSize, maxLogFileCount, logFileDir, printLog, FALSE, enableAllLevels, level, &logFn));
+
+    MEMSET(&fileLoggerPlatformCallbacks, 0x00, SIZEOF(PlatformCallbacks));
+    fileLoggerPlatformCallbacks.customData = (UINT64) NULL;
+    fileLoggerPlatformCallbacks.version = PLATFORM_CALLBACKS_CURRENT_VERSION;
+    fileLoggerPlatformCallbacks.logPrintFn = logFn;
+    fileLoggerPlatformCallbacks.freePlatformCallbacksFn = freeFileLoggerPlatformCallbacksFunc;
+
+    CHK_STATUS(setPlatformCallbacks(pClientCallbacks, &fileLoggerPlatformCallbacks));
+
+    CleanUp:
+
+    if (!STATUS_SUCCEEDED(retStatus)) {
+        freeFileLogger();
+    }
+
+    // Need to fix-up the status code from the common for back compat
+    if (retStatus == STATUS_FILE_LOGGER_INDEX_FILE_INVALID_SIZE) {
+        retStatus = STATUS_FILE_LOGGER_INDEX_FILE_TOO_LARGE;
+    }
+    return retStatus;
+}


### PR DESCRIPTION
What was changed?

- Update PIC dependency commit to https://github.com/awslabs/amazon-kinesis-video-streams-pic/commit/7b7d9d126d9ef9d354f9218e4361f72adb0a8635
- Add a new file logger platform callback to set up logging with filtering (extend PIC functionality)
- Add unit test for the new API
- Switched CI to macos-13 for gcc/clang build. There is an issue with 11 and 12 which is not reproducible on EC2 instances or locally, but shows up only on GHA.

Why was it changed?

Producer C SDK should be updated to use most recent PIC commit to have feature parity

How was it changed?

Updated the PIC commit to use up-to-date features and made reflecting changes in this SDK to extend API support

Testing:

Introduced new unit test and fixed existing file logger related unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
