### PR TITLE
Add empty string check

### DIFF
--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           7b7d9d126d9ef9d354f9218e4361f72adb0a8635
+	GIT_TAG           b7473c436ac9a0e55897ec75f71ee7f507e72265
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/src/source/Common/Auth.c
+++ b/src/source/Common/Auth.c
@@ -19,7 +19,12 @@ STATUS createAwsCredentials(PCHAR accessKeyId, UINT32 accessKeyIdLen, PCHAR secr
     CHK(ppAwsCredentials != NULL, STATUS_NULL_ARG);
 
     // Session token is optional. If NULL then the session token len should be 0
-    CHK(accessKeyId != NULL && secretKey != NULL && (sessionToken != NULL || sessionTokenLen == 0), STATUS_INVALID_ARG);
+    CHK(accessKeyId != NULL && secretKey != NULL && (sessionToken != NULL || sessionTokenLen == 0), STATUS_NULL_ARG);
+
+    CHK(!IS_EMPTY_STRING(accessKeyId) && !IS_EMPTY_STRING(secretKey), STATUS_INVALID_ARG);
+    if(sessionToken != NULL) {
+        CHK(!IS_EMPTY_STRING(sessionToken), STATUS_INVALID_ARG);
+    }
 
     // Calculate the length if not specified
     if (accessKeyIdLen == 0) {

--- a/tst/AwsCredentialsTest.cpp
+++ b/tst/AwsCredentialsTest.cpp
@@ -52,7 +52,9 @@ TEST_F(AwsCredentialsTest, createAwsCredentials)
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
 
-    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(
+    // Negative cases
+
+    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(
             EMPTY_STRING,
             0,
             EMPTY_STRING,
@@ -64,9 +66,38 @@ TEST_F(AwsCredentialsTest, createAwsCredentials)
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
 
-    // Negative cases
+    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(
+            EMPTY_STRING,
+            0,
+            TEST_SECRET_KEY,
+            0,
+            TEST_SESSION_TOKEN,
+            0,
+            0,
+            &pAwsCredentials));
 
     EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(
+            EMPTY_STRING,
+            0,
+            EMPTY_STRING,
+            0,
+            TEST_SESSION_TOKEN,
+            0,
+            0,
+            &pAwsCredentials));
+
+    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(
+            NULL,
+            0,
+            EMPTY_STRING,
+            0,
+            TEST_SESSION_TOKEN,
+            0,
+            0,
+            &pAwsCredentials));
+
+
+    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(
             NULL,
             0,
             TEST_SECRET_KEY,
@@ -77,7 +108,7 @@ TEST_F(AwsCredentialsTest, createAwsCredentials)
             &pAwsCredentials));
     EXPECT_EQ(NULL, pAwsCredentials);
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(
+    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(
             TEST_ACCESS_KEY,
             0,
             NULL,

--- a/tst/CallbacksProviderPublicApiTest.cpp
+++ b/tst/CallbacksProviderPublicApiTest.cpp
@@ -390,7 +390,7 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAwsCred
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
+    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
             TEST_ACCESS_KEY,
             TEST_SECRET_KEY,
             EMPTY_STRING,
@@ -455,7 +455,7 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAwsCred
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
+    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
             EMPTY_STRING,
             TEST_SECRET_KEY,
             TEST_SESSION_TOKEN,
@@ -468,7 +468,7 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAwsCred
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
+    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
             TEST_ACCESS_KEY,
             EMPTY_STRING,
             TEST_SESSION_TOKEN,
@@ -496,7 +496,7 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAwsCred
 
     // Negative case permutations
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAwsCredentials(
             NULL,
             TEST_SECRET_KEY,
             TEST_SESSION_TOKEN,
@@ -508,7 +508,7 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAwsCred
             &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAwsCredentials(
             TEST_ACCESS_KEY,
             NULL,
             TEST_SESSION_TOKEN,


### PR DESCRIPTION
What was changed?
- Added a check for empty AWS credentials in createAwsCredentials.

Why was it changed?
- The check ensures that we properly check the credentials being generated via IoT or being passed as long term credentials. If it is empty, we would not move ahead with other part of the state machine since getCredentials function would fail instead of passing with empty creds and failing later while making other service calls

How it was changed?
- Added a simple check in `createAwsCredentials` since this function is invoked for every credential provider

Testing:
- Increased the test coverage in the unit tests
- Local testing by passing empty strings as part of `createDefaultCallbacksProviderWithAwsCredentials` in the samples


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
