### PR TITLE
Fix user agent string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.6.3)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 include(Utilities)
-project(KinesisVideoProducerC LANGUAGES C)
+project(KinesisVideoProducerC VERSION 1.4.1 LANGUAGES C)
 
 include(GNUInstallDirs)
 
@@ -31,6 +31,8 @@ option(SET_SSL_CALLBACKS "Set SSL thread and lock callbacks." OFF)
 set(CMAKE_MACOSX_RPATH TRUE)
 
 get_filename_component(ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+
+add_definitions(-DVERSION_STRING=\"${PROJECT_VERSION}\")
 
 if(NOT KINESIS_VIDEO_PRODUCER_C_SRC)
     if(DEFINED ENV{KINESIS_VIDEO_PRODUCER_C_SRC})

--- a/src/source/Common/Version.h
+++ b/src/source/Common/Version.h
@@ -10,15 +10,16 @@ Auth internal include file
 extern "C" {
 #endif
 
-/**
- * IMPORTANT!!! This is the current version of the SDK which needs to be maintained
- */
-#define AWS_SDK_KVS_PRODUCER_VERSION_STRING (PCHAR) "3.0.0"
+#ifdef VERSION_STRING
+#define AWS_SDK_KVS_PRODUCER_VERSION_STRING (PCHAR) VERSION_STRING
+#else
+#define AWS_SDK_KVS_PRODUCER_VERSION_STRING (PCHAR) "UNKNOWN"
+#endif
 
 /**
  * Default user agent string
  */
-#define USER_AGENT_NAME (PCHAR) "AWS-SDK-KVS"
+#define USER_AGENT_NAME (PCHAR) "AWS-PRODUCER-SDK-KVS"
 
 ////////////////////////////////////////////////////
 // Function definitions


### PR DESCRIPTION
Description of changes:

What was changed?

By default, the user agent string for the Producer SDK was set to AWS-SDK-KVS/3.0.0 Set a Version specific SDK default user agent.
Why was it changed?

When trying to debug a problem that requires checking backend, it is impossible to understand the source of the request since this SDK depends on producer SDK. This change helps with the differentiation and simplify debugging

How was it changed?

Setting the default format to: AWS-PRODUCER-SDK-KVS/`<version>`
Changed the CMake to set project version which is read to set the user agent string. This would have to be changed before every release

Testing:
- Tested locally with samples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
