### PR TITLE
Set newly added timeouts to default value

### DIFF
--- a/src/source/DeviceInfoProvider.c
+++ b/src/source/DeviceInfoProvider.c
@@ -45,6 +45,8 @@ STATUS createDefaultDeviceInfo(PDeviceInfo* ppDeviceInfo)
 
     // use 0 for default values
     pDeviceInfo->clientInfo.stopStreamTimeout = 0;
+    pDeviceInfo->clientInfo.serviceCallConnectionTimeout = SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT;
+    pDeviceInfo->clientInfo.serviceCallCompletionTimeout = SERVICE_CALL_DEFAULT_TIMEOUT;
     pDeviceInfo->clientInfo.createClientTimeout = 0;
     pDeviceInfo->clientInfo.createStreamTimeout = 0;
 


### PR DESCRIPTION
Timeouts were added but the defaults weren't set, so this fixes that so warnings aren't output needlessly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
