### PR TITLE
Update PIC git tag to include modified Threadpool teardown

### DIFF
--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           be6d170ced7ed4b1ad7a2fbdb7cf93f1ac21f5f9
+	GIT_TAG           98cc13510eda7da08eb91cb6904c8f980aa110af
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           57637ea593f4b43c509413a44d993ed08d7f2616
+	GIT_TAG           be6d170ced7ed4b1ad7a2fbdb7cf93f1ac21f5f9
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS


### PR DESCRIPTION
*Issue #, if available:*
To fix the TSAN build issues with https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/1806

*Description of changes:*
The PIC commit https://github.com/awslabs/amazon-kinesis-video-streams-pic/pull/218 fixes the TSAN build issues in WebRTC. We need to modify the same in Producer C to propagate it to WebRTC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
