### PR TITLE
Daveisfera pr 397

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ For audio only, run `./kvsAudioOnlyStreamingSample <stream-name> <streaming_dura
 
 This will stream the audio files from the `samples/aacSampleFrames` or `samples/alawSampleFrames` (as per the choice of audio codec in the last argument) respectively. 
 
+### Fragment metadata
+
+`./kvsVideoOnlyRealtimeStreamingSample` is the only sample that has the [fragment metadata](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-meta.html) implemented out of the box.
+
+In addition to the required arguments above, this sample has an additional argument:
+```shell
+./kvsVideoOnlyRealtimeStreamingSample <stream-name> <video-codec> <streaming-duration-in-seconds> <sample-location> <num-metadata>
+```
+
+`num-metadata` -- the number of sample fragment metadata key-value pairs that are added to each fragment. Min: 0, Max: 10. Default: 10.
+
 ### Setting log levels
 
 

--- a/samples/KvsVideoOnlyRealtimeStreamingSample.c
+++ b/samples/KvsVideoOnlyRealtimeStreamingSample.c
@@ -113,7 +113,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 6 && !IS_EMPTY_STRING(argv[5])) {
         numMetadata = STRTOUL(argv[5], NULL, 10);
-        DLOGE("numMetadata: %d\n", numMetadata);
+        DLOGD("numMetadata: %d\n", numMetadata);
         CHK(numMetadata <= MAX_METADATA_PER_FRAGMENT, STATUS_INVALID_ARG);
     }
 

--- a/samples/KvsVideoOnlyRealtimeStreamingSample.c
+++ b/samples/KvsVideoOnlyRealtimeStreamingSample.c
@@ -113,7 +113,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 6 && !IS_EMPTY_STRING(argv[5])) {
         numMetadata = STRTOUL(argv[5], NULL, 10);
-        DLOGD("numMetadata: %d\n", numMetadata);
+        DLOGE("numMetadata: %d\n", numMetadata);
         CHK(numMetadata <= MAX_METADATA_PER_FRAGMENT, STATUS_INVALID_ARG);
     }
 
@@ -165,7 +165,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
         // Add the fragment metadata key-value pairs
         // For limits, refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html#limits-streaming-metadata
-        if (frame.flags == FRAME_FLAG_KEY_FRAME) {
+        if (numMetadata > 0 && frame.flags == FRAME_FLAG_KEY_FRAME) {
             DLOGD("Adding metadata! frameIndex: %d", frame.index);
             for (n = 1; n <= numMetadata; n++) {
                 SNPRINTF(metadataKey, METADATA_MAX_KEY_LENGTH, "TEST_KEY_%d", n);


### PR DESCRIPTION
#394 / #397, with some small modifications + running the tests

1. Use IS_EMPTY_STRING macro from PIC
2. Use the maximum lengths defined in https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html#limits-streaming-metadata instead of arbitrary 200 (which goes past 128 for key length).
3. Use SNPRINTF macro from PIC instead of `sprintf`.
4. Update the README.

Manual tests:
* `./kvsVideoOnlyRealtimeStreamingSample test-stream h264 ""  ../samples 0` -- works ✅ 
* `./kvsVideoOnlyRealtimeStreamingSample test-stream h264 ""  ../samples 11` -- errors and exits ✅ 
* `./kvsVideoOnlyRealtimeStreamingSample test-stream h264 ""  ../samples 9` --  works ✅ 

* See the mkv tags appended using mkvinfo. Procedure:
```
export KVS_DEBUG_DUMP_DATA_FILE_DIR=`pwd`/media
mkdir media
./kvsVideoOnlyRealtimeStreamingSample test-stream
mkvinfo -v ./media/test-stream_0.mkv
```

<img width="509" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/assets/14988194/dd1330c5-da1d-4d26-bf61-896053abed33">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
