### PR TITLE
Update thing name length to be 128 as per AWS docs

### DIFF
--- a/scripts/generate-iot-credential.sh
+++ b/scripts/generate-iot-credential.sh
@@ -3,7 +3,6 @@
 # You can use this script to setup environment variables in the shell which samples run on.
 # https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html
 
-prefix=$1
 thingName="producerc_thing"
 thingTypeName="producerc_thing_type"
 iotPolicyName="producerc_policy"

--- a/src/include/com/amazonaws/kinesis/video/common/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/common/Include.h
@@ -139,9 +139,9 @@ extern "C" {
 #define MAX_ROLE_ALIAS_LEN 128
 
 /**
- * Maximum allowed string length for IoT thing name
+ * Maximum allowed string length for IoT thing name: https://docs.aws.amazon.com/iot/latest/apireference/API_CreateThing.html
  */
-#define MAX_IOT_THING_NAME_LEN MAX_STREAM_NAME_LEN
+#define MAX_IOT_THING_NAME_LEN 128
 
 /**
  * Maximum allowed request header length


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Our thing name length is currently set to 256 characters (stream name length). However, as per https://docs.aws.amazon.com/iot/latest/apireference/API_CreateThing.html, it is 128 characters. Since our SDK does not create the thing, the failure would be caught in the out of band thing creation step anyways. However, we need this change to be accurate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
