### PR TITLE
run windows tests with debug logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
   windows-msvc:
     runs-on: windows-2022
     env:
-      AWS_KVS_LOG_LEVEL: 7
+      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read

--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -1328,7 +1328,7 @@ PVOID describeStreamCurlHandler(PVOID arg)
     UINT32 i, strLen, resultLen;
     INT32 tokenCount;
     UINT64 retention;
-    BOOL jsonInStreamDescription = FALSE, requestTerminating = FALSE;
+    BOOL jsonInStreamDescription = FALSE, requestTerminating = FALSE, responseReceived = FALSE;
     StreamDescription streamDescription;
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     SERVICE_CALL_RESULT callResult = SERVICE_CALL_RESULT_NOT_SET;
@@ -1361,8 +1361,7 @@ PVOID describeStreamCurlHandler(PVOID arg)
     CHK(pCurlResponse->callInfo.callResult != SERVICE_CALL_RESULT_NOT_SET, STATUS_INVALID_OPERATION);
     pResponseStr = pCurlResponse->callInfo.responseData;
     resultLen = pCurlResponse->callInfo.responseDataLen;
-
-    DLOGD("[%s] DescribeStream API response: %.*s", streamDescription.streamName, resultLen, pResponseStr);
+    responseReceived = TRUE;
 
     // skip json parsing if call result not ok
     CHK(pCurlResponse->callInfo.callResult == SERVICE_CALL_RESULT_OK && resultLen != 0 && pResponseStr != NULL, retStatus);
@@ -1440,6 +1439,10 @@ PVOID describeStreamCurlHandler(PVOID arg)
     }
 
 CleanUp:
+
+    if (responseReceived) {
+        DLOGD("[%s] DescribeStream API response: %.*s", streamDescription.streamName, resultLen, pResponseStr);
+    }
 
     // Preserve the values as we need to free the request before the event notification
     if (pCurlRequest->pCurlResponse != NULL) {

--- a/tst/ProducerTestFixture.cpp
+++ b/tst/ProducerTestFixture.cpp
@@ -339,7 +339,7 @@ ProducerClientTestBase::ProducerClientTestBase() :
     mFps = TEST_FPS;
     mKeyFrameInterval = TEST_FPS;
     mFrameSize = TEST_FRAME_SIZE;
-    mFrameBuffer = (PBYTE) MEMALLOC(mFrameSize);
+    mFrameBuffer = (PBYTE) MEMCALLOC(mFrameSize, SIZEOF(BYTE));
 
     mFrame.duration = HUNDREDS_OF_NANOS_IN_A_SECOND / mFps;
     mFrame.frameData = mFrameBuffer;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* CALLOC frame buffer to prevent garbage data
* DescribeStream API response wait until stream definition is memset and populated before printing out log line otherwise on some platforms you will get a lot of garbage (we were seeing that on Windows).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
