### PR TITLE
Mbedtls link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,28 @@ jobs:
           cd build
           ./tst/producer_test
 
+  ubuntu-os-build-lws-mbedtls:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CC: gcc
+      CXX: g++
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_COMMON_LWS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make
+
   linux-gcc-code-coverage:
     runs-on: ubuntu-20.04
     env:
@@ -268,6 +290,7 @@ jobs:
           cd build
           ulimit -c unlimited -S
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+
 
   # memory-sanitizer:
   #   runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           cd build
           ./tst/producer_test
 
-  ubuntu-os-build-lws-mbedtls:
+  ubuntu-os-gcc-build-lws-mbedtls:
     runs-on: ubuntu-20.04
     env:
       AWS_KVS_LOG_LEVEL: 2
@@ -195,7 +195,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_COMMON_LWS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          cmake .. -DBUILD_COMMON_LWS=ON -DBUILD_COMMON_CURL=OFF -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
           make
 
   linux-gcc-code-coverage:

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           develop
+	GIT_TAG           tp-term-log
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           tp-term-log
+	GIT_TAG           develop
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ if(BUILD_COMMON_LWS)
     target_link_libraries(kvsCommonLws
             ${OPENSSL_CRYPTO_LIBRARY}
             ${OPENSSL_SSL_LIBRARY}
+            ${MBEDTLS_LIBRARIES}
             ${LIBWEBSOCKETS_LIBRARIES}
             kvspicUtils)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,9 +289,7 @@ if(BUILD_COMMON_LWS)
       set_target_properties(kvsCommonLws PROPERTIES VERSION ${KINESIS_VIDEO_PRODUCER_C_VERSION} SOVERSION ${KINESIS_VIDEO_PRODUCER_C_MAJOR_VERSION})
     endif()
     target_link_libraries(kvsCommonLws
-            ${OPENSSL_CRYPTO_LIBRARY}
-            ${OPENSSL_SSL_LIBRARY}
-            ${MBEDTLS_LIBRARIES}
+            ${PRODUCER_CRYPTO_LIBRARY}
             ${LIBWEBSOCKETS_LIBRARIES}
             kvspicUtils)
 


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Fixed the linking for LWS case to be crypto specific.

*Why was it changed?*
- The crypto linking is different for LWS vs CURL. In LWS case for this library, the library was always being linked to openssl, but it should link based on crypto library set up.

*How was it changed?*
- Linking to `PRODUCER_CRYPTO_LIBRARY` instead of Openssl only.

Before this change: (`libmbedcrypto.so.7 => not found`)

```
ubuntu@ip-172-31-11-82:~/amazon-kinesis-video-streams-producer-c/build$ ldd libkvsCommonLws.so
	linux-vdso.so.1 (0x00007fffcbf08000)
	libwebsockets.so.15 => /home/ubuntu/amazon-kinesis-video-streams-producer-c/open-source/lib/libwebsockets.so.15 (0x00007f32d5b7a000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f32d5800000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f32d5bcf000)
	libmbedtls.so.14 => not found
	libmbedx509.so.1 => not found
	libmbedcrypto.so.7 => not found
```

After this change: (`libmbedcrypto.so.7 => /home/ubuntu/amazon-kinesis-video-streams-producer-c/open-source/lib/libmbedcrypto.so.7 (0x00007f8518325000)`)

```
ubuntu@ip-172-31-11-82:~/amazon-kinesis-video-streams-producer-c/build$ ldd libkvsCommonLws.so
	linux-vdso.so.1 (0x00007ffdfdb56000)
	libmbedcrypto.so.7 => /home/ubuntu/amazon-kinesis-video-streams-producer-c/open-source/lib/libmbedcrypto.so.7 (0x00007f8518325000)
	libwebsockets.so.19 => /home/ubuntu/amazon-kinesis-video-streams-producer-c/open-source/lib/libwebsockets.so.19 (0x00007f85182c6000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f8518000000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f85183b4000)
	libmbedtls.so.14 => not found
	libmbedx509.so.1 => not found
```

*What testing was done for the changes?*
- Added CI to only test the build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
