### PR TITLE
Fix some of the CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: gcc-14
-      CXX: gcc-14
+      CC: gcc-12
+      CXX: gcc-12
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
@@ -115,8 +115,8 @@ jobs:
   mac-os-m1-build-gcc:
     runs-on: macos-13-xlarge
     env:
-      CC: gcc-14
-      CXX: gcc-14
+      CC: gcc-12
+      CXX: gcc-12
       AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,60 +304,60 @@ jobs:
           ulimit -c unlimited -S
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  memory-sanitizer:
-    runs-on: ubuntu-20.04
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-          make
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  # memory-sanitizer:
+  #   runs-on: ubuntu-20.04
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   env:
+  #     CC: clang
+  #     CXX: clang++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  thread-sanitizer:
-   runs-on: ubuntu-20.04
-   permissions:
-     id-token: write
-     contents: read
-   env:
-     CC: clang
-     CXX: clang++
-     AWS_KVS_LOG_LEVEL: 2
-   steps:
-     - name: Clone repository
-       uses: actions/checkout@v3
-     - name: Configure AWS Credentials
-       uses: aws-actions/configure-aws-credentials@v1-node16
-       with:
-         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-         aws-region: ${{ secrets.AWS_REGION }}
-     - name: Build repository
-       run: |
-         mkdir build && cd build
-         cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-         make
-     - name: Run tests
-       run: |
-         cd build
-         ulimit -c unlimited -S
-         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  # thread-sanitizer:
+  #  runs-on: ubuntu-20.04
+  #  permissions:
+  #    id-token: write
+  #    contents: read
+  #  env:
+  #    CC: clang
+  #    CXX: clang++
+  #    AWS_KVS_LOG_LEVEL: 2
+  #  steps:
+  #    - name: Clone repository
+  #      uses: actions/checkout@v3
+  #    - name: Configure AWS Credentials
+  #      uses: aws-actions/configure-aws-credentials@v1-node16
+  #      with:
+  #        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #        role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #        aws-region: ${{ secrets.AWS_REGION }}
+  #    - name: Build repository
+  #      run: |
+  #        mkdir build && cd build
+  #        cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+  #        make
+  #    - name: Run tests
+  #      run: |
+  #        cd build
+  #        ulimit -c unlimited -S
+  #        timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   ubuntu-gcc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ on:
       - develop
       - master
 jobs:
-  # clang-format-check:
-  #   runs-on: macos-11
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Install clang-format
-  #       run: |
-  #         brew install clang-format
-  #         clang-format --version
-  #     - name: Run clang format check
-  #       run: |
-  #         bash scripts/check-clang.sh
+  clang-format-check:
+    runs-on: macos-11
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install clang-format
+        run: |
+          brew install clang-format
+          clang-format --version
+      - name: Run clang format check
+        run: |
+          bash scripts/check-clang.sh
 
   mac-os-build-gcc:
     runs-on: macos-latest
@@ -54,63 +54,63 @@ jobs:
           cd build
           ./tst/producer_test
 
-  # mac-os-build-clang:
-  #   runs-on: macos-11
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build repository
-  #       run: |
-  #         brew install pkgconfig
-  #         brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ./tst/producer_test
+  mac-os-build-clang:
+    runs-on: macos-11
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build repository
+        run: |
+          brew install pkgconfig
+          brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ./tst/producer_test
 
-  # mac-os-m1-build-clang:
-  #   runs-on: macos-13-xlarge
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build repository
-  #       run: |
-  #         brew install pkgconfig
-  #         brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ./tst/producer_test
+  mac-os-m1-build-clang:
+    runs-on: macos-13-xlarge
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build repository
+        run: |
+          brew install pkgconfig
+          brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ./tst/producer_test
 
   mac-os-m1-build-gcc:
     runs-on: macos-latest-xlarge
@@ -147,347 +147,347 @@ jobs:
           cd build
           ./tst/producer_test
 
-  # mac-os-build-gcc-local-openssl:
-  #   runs-on: macos-11
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   env:
-  #     CC: /usr/local/bin/gcc-13
-  #     CXX: /usr/local/bin/g++-13
-  #     AWS_KVS_LOG_LEVEL: 2
-  #     LDFLAGS: -L/usr/local/opt/openssl@3/lib
-  #     CPPFLAGS: -I/usr/local/opt/openssl@3/include
-  #     OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build repository
-  #       run: |
-  #         brew info openssl
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DLOCAL_OPENSSL_BUILD=ON
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ./tst/producer_test
+  mac-os-build-gcc-local-openssl:
+    runs-on: macos-11
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CC: /usr/local/bin/gcc-13
+      CXX: /usr/local/bin/g++-13
+      AWS_KVS_LOG_LEVEL: 2
+      LDFLAGS: -L/usr/local/opt/openssl@3/lib
+      CPPFLAGS: -I/usr/local/opt/openssl@3/include
+      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build repository
+        run: |
+          brew info openssl
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DLOCAL_OPENSSL_BUILD=ON
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ./tst/producer_test
 
-  # mac-os-build-clang-local-openssl:
-  #   runs-on: macos-latest
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 2
-  #     LDFLAGS: -L/usr/local/opt/openssl@3/lib
-  #     CPPFLAGS: -I/usr/local/opt/openssl@3/include
-  #     OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build repository
-  #       run: |
-  #         brew info openssl
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DLOCAL_OPENSSL_BUILD=ON
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ./tst/producer_test
+  mac-os-build-clang-local-openssl:
+    runs-on: macos-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      LDFLAGS: -L/usr/local/opt/openssl@3/lib
+      CPPFLAGS: -I/usr/local/opt/openssl@3/include
+      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build repository
+        run: |
+          brew info openssl
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DLOCAL_OPENSSL_BUILD=ON
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ./tst/producer_test
 
-  # linux-gcc-code-coverage:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_COMMON_LWS=TRUE
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
-  #     - name: Code coverage
-  #       run: |
-  #         cd build
-  #         for test_file in $(find cproducer.dir kvsCommonCurl.dir kvsCommonLws.dir -name '*.gcno'); do gcov $test_file; done
-  #         bash <(curl -s https://codecov.io/bash)
+  linux-gcc-code-coverage:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_COMMON_LWS=TRUE
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+      - name: Code coverage
+        run: |
+          cd build
+          for test_file in $(find cproducer.dir kvsCommonCurl.dir kvsCommonLws.dir -name '*.gcno'); do gcov $test_file; done
+          bash <(curl -s https://codecov.io/bash)
 
-  # address-sanitizer:
-  #   runs-on: ubuntu-20.04
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   env:
-  #     CC: clang
-  #     CXX: clang++
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  address-sanitizer:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  # undefined-behavior-sanitizer:
-  #   runs-on: ubuntu-20.04
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   env:
-  #     CC: clang
-  #     CXX: clang++
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  undefined-behavior-sanitizer:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  # memory-sanitizer:
-  #   runs-on: ubuntu-20.04
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   env:
-  #     CC: clang
-  #     CXX: clang++
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-  #         make
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  memory-sanitizer:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+          make
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  #thread-sanitizer:
-  #  runs-on: ubuntu-20.04
-  #  permissions:
-  #    id-token: write
-  #    contents: read
-  #  env:
-  #    CC: clang
-  #    CXX: clang++
-  #    AWS_KVS_LOG_LEVEL: 2
-  #  steps:
-  #    - name: Clone repository
-  #      uses: actions/checkout@v3
-  #    - name: Configure AWS Credentials
-  #      uses: aws-actions/configure-aws-credentials@v1-node16
-  #      with:
-  #        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #        role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #        aws-region: ${{ secrets.AWS_REGION }}
-  #    - name: Build repository
-  #      run: |
-  #        mkdir build && cd build
-  #        cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-  #        make
-  #    - name: Run tests
-  #      run: |
-  #        cd build
-  #        ulimit -c unlimited -S
-  #        timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  thread-sanitizer:
+   runs-on: ubuntu-20.04
+   permissions:
+     id-token: write
+     contents: read
+   env:
+     CC: clang
+     CXX: clang++
+     AWS_KVS_LOG_LEVEL: 2
+   steps:
+     - name: Clone repository
+       uses: actions/checkout@v3
+     - name: Configure AWS Credentials
+       uses: aws-actions/configure-aws-credentials@v1-node16
+       with:
+         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+         aws-region: ${{ secrets.AWS_REGION }}
+     - name: Build repository
+       run: |
+         mkdir build && cd build
+         cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+         make
+     - name: Run tests
+       run: |
+         cd build
+         ulimit -c unlimited -S
+         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  # ubuntu-gcc:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 2
-  #     CC: gcc
-  #     CXX: g++
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #     - name: Build repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE
-  #         make
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         cd build
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  ubuntu-gcc:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CC: gcc
+      CXX: g++
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE
+          make
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          cd build
+          ulimit -c unlimited -S
+          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  # windows-msvc:
-  #   runs-on: windows-2022
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Install dependencies
-  #       run: |
-  #         choco install nasm strawberryperl pkgconfiglite
-  #     - name: Build repository
-  #       run: |
-  #         $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
-  #         git config --system core.longpaths true
-  #         .github/build_windows.bat
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-  #         role-duration-seconds: 10800
-  #     - name: Run tests
-  #       run: |
-  #         $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
-  #         & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
+  windows-msvc:
+    runs-on: windows-2022
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          choco install nasm strawberryperl pkgconfiglite
+      - name: Build repository
+        run: |
+          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
+          git config --system core.longpaths true
+          .github/build_windows.bat
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
+          & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
 
-  # arm64-cross-compilation:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     CC: aarch64-linux-gnu-gcc
-  #     CXX: aarch64-linux-gnu-g++
-  #   steps:
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build Repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64
-  #         make
-  #         file libcproducer.so
-  # linux-aarch64-cross-compilation:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     CC: aarch64-linux-gnu-gcc
-  #     CXX: aarch64-linux-gnu-g++
-  #   steps:
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build Repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64
-  #         make
-  #         file libcproducer.so
-  # arm32-cross-compilation:
-  #   runs-on: ubuntu-20.04
-  #   env:
-  #     CC: arm-linux-gnueabi-gcc
-  #     CXX: arm-linux-gnueabi-g++
-  #   steps:
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build Repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32
-  #         make
-  #         file libcproducer.so
+  arm64-cross-compilation:
+    runs-on: ubuntu-20.04
+    env:
+      CC: aarch64-linux-gnu-gcc
+      CXX: aarch64-linux-gnu-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64
+          make
+          file libcproducer.so
+  linux-aarch64-cross-compilation:
+    runs-on: ubuntu-20.04
+    env:
+      CC: aarch64-linux-gnu-gcc
+      CXX: aarch64-linux-gnu-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64
+          make
+          file libcproducer.so
+  arm32-cross-compilation:
+    runs-on: ubuntu-20.04
+    env:
+      CC: arm-linux-gnueabi-gcc
+      CXX: arm-linux-gnueabi-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32
+          make
+          file libcproducer.so
 
-  # linux-build-gcc-static:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v3
-  #     - name: Build Repository
-  #       run: |
-  #         mkdir build && cd build
-  #         cmake .. -DBUILD_STATIC=ON
-  #         make
+  linux-build-gcc-static:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Build Repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_STATIC=ON
+          make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     env:
       CC: gcc-13
-      CXX: gcc-13
+      CXX: g++-13
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
@@ -116,7 +116,7 @@ jobs:
     runs-on: macos-latest-xlarge
     env:
       CC: gcc-13
-      CXX: gcc-13
+      CXX: g++-13
       AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   #         bash scripts/check-clang.sh
 
   mac-os-build-gcc:
-    runs-on: macos-12
+    runs-on: macos-latest
     permissions:
       id-token: write
       contents: read
@@ -113,7 +113,7 @@ jobs:
   #         ./tst/producer_test
 
   mac-os-m1-build-gcc:
-    runs-on: macos-14-xlarge
+    runs-on: macos-latest-xlarge
     env:
       CC: gcc-13
       CXX: gcc-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
   #         bash scripts/check-clang.sh
 
   mac-os-build-gcc:
-    runs-on: macos-11
+    runs-on: macos-12
     permissions:
       id-token: write
       contents: read
     env:
-      CC: gcc-12
-      CXX: gcc-12
+      CC: gcc-13
+      CXX: gcc-13
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
@@ -115,8 +115,8 @@ jobs:
   mac-os-m1-build-gcc:
     runs-on: macos-14-xlarge
     env:
-      CC: gcc-12
-      CXX: gcc-12
+      CC: gcc-13
+      CXX: gcc-13
       AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           bash scripts/check-clang.sh
 
   mac-os-build-gcc:
-    runs-on: macos-12
+    runs-on: macos-11
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          choco install nasm strawberryperl
+          choco install nasm strawberryperl pkgconfiglite
       - name: Build repository
         run: |
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ on:
       - develop
       - master
 jobs:
-  clang-format-check:
-    runs-on: macos-11
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install clang-format
-        run: |
-          brew install clang-format
-          clang-format --version
-      - name: Run clang format check
-        run: |
-          bash scripts/check-clang.sh
+  # clang-format-check:
+  #   runs-on: macos-11
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Install clang-format
+  #       run: |
+  #         brew install clang-format
+  #         clang-format --version
+  #     - name: Run clang format check
+  #       run: |
+  #         bash scripts/check-clang.sh
 
   mac-os-build-gcc:
     runs-on: macos-11
@@ -54,66 +54,66 @@ jobs:
           cd build
           ./tst/producer_test
 
-  mac-os-build-clang:
-    runs-on: macos-11
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build repository
-        run: |
-          brew install pkgconfig
-          brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+  # mac-os-build-clang:
+  #   runs-on: macos-11
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build repository
+  #       run: |
+  #         brew install pkgconfig
+  #         brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ./tst/producer_test
 
-  mac-os-m1-build-clang:
-    runs-on: macos-13-xlarge
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build repository
-        run: |
-          brew install pkgconfig
-          brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+  # mac-os-m1-build-clang:
+  #   runs-on: macos-13-xlarge
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build repository
+  #       run: |
+  #         brew install pkgconfig
+  #         brew unlink openssl # it seems the libcurl is trying to access this openssl despite explicitly setting it to our build
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ./tst/producer_test
 
   mac-os-m1-build-gcc:
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
     env:
       CC: gcc-12
       CXX: gcc-12
@@ -147,162 +147,162 @@ jobs:
           cd build
           ./tst/producer_test
 
-  mac-os-build-gcc-local-openssl:
-    runs-on: macos-11
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: /usr/local/bin/gcc-13
-      CXX: /usr/local/bin/g++-13
-      AWS_KVS_LOG_LEVEL: 2
-      LDFLAGS: -L/usr/local/opt/openssl@3/lib
-      CPPFLAGS: -I/usr/local/opt/openssl@3/include
-      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build repository
-        run: |
-          brew info openssl
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DLOCAL_OPENSSL_BUILD=ON
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+  # mac-os-build-gcc-local-openssl:
+  #   runs-on: macos-11
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   env:
+  #     CC: /usr/local/bin/gcc-13
+  #     CXX: /usr/local/bin/g++-13
+  #     AWS_KVS_LOG_LEVEL: 2
+  #     LDFLAGS: -L/usr/local/opt/openssl@3/lib
+  #     CPPFLAGS: -I/usr/local/opt/openssl@3/include
+  #     OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build repository
+  #       run: |
+  #         brew info openssl
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DLOCAL_OPENSSL_BUILD=ON
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ./tst/producer_test
 
-  mac-os-build-clang-local-openssl:
-    runs-on: macos-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-      LDFLAGS: -L/usr/local/opt/openssl@3/lib
-      CPPFLAGS: -I/usr/local/opt/openssl@3/include
-      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build repository
-        run: |
-          brew info openssl
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DLOCAL_OPENSSL_BUILD=ON
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+  # mac-os-build-clang-local-openssl:
+  #   runs-on: macos-latest
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #     LDFLAGS: -L/usr/local/opt/openssl@3/lib
+  #     CPPFLAGS: -I/usr/local/opt/openssl@3/include
+  #     OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build repository
+  #       run: |
+  #         brew info openssl
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DLOCAL_OPENSSL_BUILD=ON
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ./tst/producer_test
 
-  linux-gcc-code-coverage:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_COMMON_LWS=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
-      - name: Code coverage
-        run: |
-          cd build
-          for test_file in $(find cproducer.dir kvsCommonCurl.dir kvsCommonLws.dir -name '*.gcno'); do gcov $test_file; done
-          bash <(curl -s https://codecov.io/bash)
+  # linux-gcc-code-coverage:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_COMMON_LWS=TRUE
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  #     - name: Code coverage
+  #       run: |
+  #         cd build
+  #         for test_file in $(find cproducer.dir kvsCommonCurl.dir kvsCommonLws.dir -name '*.gcno'); do gcov $test_file; done
+  #         bash <(curl -s https://codecov.io/bash)
 
-  address-sanitizer:
-    runs-on: ubuntu-20.04
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  # address-sanitizer:
+  #   runs-on: ubuntu-20.04
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   env:
+  #     CC: clang
+  #     CXX: clang++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  undefined-behavior-sanitizer:
-    runs-on: ubuntu-20.04
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  # undefined-behavior-sanitizer:
+  #   runs-on: ubuntu-20.04
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   env:
+  #     CC: clang
+  #     CXX: clang++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   # memory-sanitizer:
   #   runs-on: ubuntu-20.04
@@ -359,135 +359,135 @@ jobs:
   #        ulimit -c unlimited -S
   #        timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  ubuntu-gcc:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-      CC: gcc
-      CXX: g++
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          cd build
-          ulimit -c unlimited -S
-          timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
+  # ubuntu-gcc:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #     CC: gcc
+  #     CXX: g++
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE
+  #         make
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         cd build
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  windows-msvc:
-    runs-on: windows-2022
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          choco install nasm strawberryperl pkgconfiglite
-      - name: Build repository
-        run: |
-          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
-          git config --system core.longpaths true
-          .github/build_windows.bat
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
-          & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
+  # windows-msvc:
+  #   runs-on: windows-2022
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Install dependencies
+  #       run: |
+  #         choco install nasm strawberryperl pkgconfiglite
+  #     - name: Build repository
+  #       run: |
+  #         $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
+  #         git config --system core.longpaths true
+  #         .github/build_windows.bat
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #         role-duration-seconds: 10800
+  #     - name: Run tests
+  #       run: |
+  #         $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
+  #         & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
 
-  arm64-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: aarch64-linux-gnu-gcc
-      CXX: aarch64-linux-gnu-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64
-          make
-          file libcproducer.so
-  linux-aarch64-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: aarch64-linux-gnu-gcc
-      CXX: aarch64-linux-gnu-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64
-          make
-          file libcproducer.so
-  arm32-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: arm-linux-gnueabi-gcc
-      CXX: arm-linux-gnueabi-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32
-          make
-          file libcproducer.so
+  # arm64-cross-compilation:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CC: aarch64-linux-gnu-gcc
+  #     CXX: aarch64-linux-gnu-g++
+  #   steps:
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build Repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64
+  #         make
+  #         file libcproducer.so
+  # linux-aarch64-cross-compilation:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CC: aarch64-linux-gnu-gcc
+  #     CXX: aarch64-linux-gnu-g++
+  #   steps:
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build Repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64
+  #         make
+  #         file libcproducer.so
+  # arm32-cross-compilation:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CC: arm-linux-gnueabi-gcc
+  #     CXX: arm-linux-gnueabi-g++
+  #   steps:
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build Repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32
+  #         make
+  #         file libcproducer.so
 
-  linux-build-gcc-static:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Build Repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_STATIC=ON
-          make
+  # linux-build-gcc-static:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Build Repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_STATIC=ON
+  #         make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: /usr/local/bin/gcc-13
-      CXX: /usr/local/bin/g++-13
+      CC: gcc-14
+      CXX: gcc-14
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
@@ -115,8 +115,8 @@ jobs:
   mac-os-m1-build-gcc:
     runs-on: macos-13-xlarge
     env:
-      CC: /opt/homebrew/bin/gcc-13
-      CXX: /opt/homebrew/bin/g++-13
+      CC: gcc-14
+      CXX: gcc-14
       AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6.3)
-
+#test
 project(KinesisVideoProducerC LANGUAGES C)
 
 file(GLOB_RECURSE HEADERS "include/*.h")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6.3)
-#test
+
 project(KinesisVideoProducerC LANGUAGES C)
 
 file(GLOB_RECURSE HEADERS "include/*.h")


### PR DESCRIPTION
Fixed the Intel-Mac GCC job by updating runner version, changed it to "latest". 

Cleaned up GCC path. In order for the Mac runner to use GCC over CLANG, the GCC version (i.e. "-13") _must_ be tagged onto the compiler name when setting compilers, however, the full path is not required.

Fixed the Windows CI job by installing pkgconfiglite since it was failing due to not finding pkgconfig which in other repositories we rely on external libraries such as GStreaemer to bring in for Windows builds.