### PR TITLE
Bump the runner images & fix the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           cmake .. --trace -DBUILD_TEST=TRUE
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -72,7 +72,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -101,7 +101,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -132,7 +132,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -165,7 +165,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DLOCAL_OPENSSL_BUILD=ON
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -196,7 +196,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DLOCAL_OPENSSL_BUILD=ON
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -223,7 +223,7 @@ jobs:
           cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_COMMON_LWS=TRUE
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -258,7 +258,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -288,7 +288,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -313,7 +313,7 @@ jobs:
   #     - name: Clone repository
   #       uses: actions/checkout@v3
   #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1-node16
+  #       uses: aws-actions/configure-aws-credentials@v4
   #       with:
   #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
   #         role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -339,7 +339,7 @@ jobs:
   #    - name: Clone repository
   #      uses: actions/checkout@v3
   #    - name: Configure AWS Credentials
-  #      uses: aws-actions/configure-aws-credentials@v1-node16
+  #      uses: aws-actions/configure-aws-credentials@v4
   #      with:
   #        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
   #        role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -377,7 +377,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE
           make
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -408,7 +408,7 @@ jobs:
           git config --system core.longpaths true
           .github/build_windows.bat
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
+          export ASAN_OPTIONS=use_sigaltstack=false # https://github.com/llvm/llvm-project/issues/55785
           cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
           make
       - name: Configure AWS Credentials
@@ -271,6 +272,7 @@ jobs:
         run: |
           cd build
           ulimit -c unlimited -S
+          export UBSAN_OPTIONS=use_sigaltstack=false # https://github.com/llvm/llvm-project/issues/55785
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   undefined-behavior-sanitizer:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           bash scripts/check-clang.sh
 
   mac-os-build-gcc:
-    runs-on: macos-12
+    runs-on: macos-13
     permissions:
       id-token: write
       contents: read
@@ -55,7 +55,7 @@ jobs:
           ./tst/producer_test
 
   mac-os-build-clang:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:
@@ -144,7 +144,7 @@ jobs:
           ./tst/producer_test
 
   mac-os-build-gcc-local-openssl:
-    runs-on: macos-12
+    runs-on: macos-13
     permissions:
       id-token: write
       contents: read
@@ -177,7 +177,7 @@ jobs:
           ./tst/producer_test
 
   mac-os-build-clang-local-openssl:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       AWS_KVS_LOG_LEVEL: 2
       LDFLAGS: -L/usr/local/opt/openssl@3/lib
@@ -208,7 +208,7 @@ jobs:
           ./tst/producer_test
 
   linux-gcc-code-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:
@@ -241,7 +241,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash)
 
   address-sanitizer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -271,7 +271,7 @@ jobs:
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   undefined-behavior-sanitizer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -356,7 +356,7 @@ jobs:
   #        timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   ubuntu-gcc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       AWS_KVS_LOG_LEVEL: 2
       CC: gcc
@@ -420,7 +420,7 @@ jobs:
           & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
 
   arm64-cross-compilation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -439,7 +439,7 @@ jobs:
           make
           file libcproducer.so
   linux-aarch64-cross-compilation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -458,7 +458,7 @@ jobs:
           make
           file libcproducer.so
   arm32-cross-compilation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: arm-linux-gnueabi-gcc
       CXX: arm-linux-gnueabi-g++
@@ -478,7 +478,7 @@ jobs:
           file libcproducer.so
 
   linux-build-gcc-static:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,19 +246,15 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: clang-11
-      CXX: clang++-11
+      CC: clang
+      CXX: clang++
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
-      - name: Install clang 11
-        run: |
-          sudo apt-get install clang-11 libc++-11-dev libc++abi-11-dev
       - name: Build repository
         run: |
           mkdir build && cd build
-          export ASAN_OPTIONS=use_sigaltstack=false # https://github.com/llvm/llvm-project/issues/55785
           cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
           make
       - name: Configure AWS Credentials
@@ -272,7 +268,6 @@ jobs:
         run: |
           cd build
           ulimit -c unlimited -S
-          export UBSAN_OPTIONS=use_sigaltstack=false # https://github.com/llvm/llvm-project/issues/55785
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   undefined-behavior-sanitizer:
@@ -281,15 +276,12 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: clang-11
-      CXX: clang++-11
+      CC: clang
+      CXX: clang++
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
-      - name: Install clang 11
-        run: |
-          sudo apt-get install clang-11 libc++-11-dev libc++abi-11-dev
       - name: Build repository
         run: |
           mkdir build && cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,12 +246,15 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: clang
-      CXX: clang++
+      CC: clang-11
+      CXX: clang++-11
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Install clang 11
+        run: |
+          sudo apt-get install clang-11 libc++-11-dev libc++abi-11-dev
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -276,12 +279,15 @@ jobs:
       id-token: write
       contents: read
     env:
-      CC: clang
-      CXX: clang++
+      CC: clang-11
+      CXX: clang++-11
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Install clang 11
+        run: |
+          sudo apt-get install clang-11 libc++-11-dev libc++abi-11-dev
       - name: Build repository
         run: |
           mkdir build && cd build

--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -18,13 +18,17 @@ else()
   set(LWS_WITH_MBEDTLS OFF)
 endif()
 
+# -- v3.2.3 of LWS does not support DISABLE_WERROR flag. Needed for Clang-14. --
+# Save original CMAKE_C_FLAGS and append -Wno-error to CMAKE_C_FLAGS
+set(ORIGINAL_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
+
 ExternalProject_Add(project_libwebsockets
     GIT_REPOSITORY    https://github.com/warmcat/libwebsockets.git
     GIT_TAG           v3.2.3
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
-        -DDISABLE_WERROR=1
         -DLWS_WITH_HTTP2=1
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DLWS_HAVE_HMAC_CTX_new=1
@@ -47,3 +51,6 @@ ExternalProject_Add(project_libwebsockets
         BUILD_ALWAYS      TRUE
     TEST_COMMAND      ""
 )
+
+# Revert CMAKE_C_FLAGS afterwards
+set(CMAKE_C_FLAGS "${ORIGINAL_CMAKE_C_FLAGS}")

--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -24,6 +24,7 @@ ExternalProject_Add(project_libwebsockets
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
+        -DDISABLE_WERROR=ON
         -DLWS_WITH_HTTP2=1
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DLWS_HAVE_HMAC_CTX_new=1

--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -18,10 +18,8 @@ else()
   set(LWS_WITH_MBEDTLS OFF)
 endif()
 
-# -- v3.2.3 of LWS does not support DISABLE_WERROR flag. Needed for Clang-14. --
-# Save original CMAKE_C_FLAGS and append -Wno-error to CMAKE_C_FLAGS
-set(ORIGINAL_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
+# v3.2.3 of LWS does not support DISABLE_WERROR flag. Needed for Clang-14 due to build warnings
+set(LWS_CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
 
 ExternalProject_Add(project_libwebsockets
     GIT_REPOSITORY    https://github.com/warmcat/libwebsockets.git
@@ -29,6 +27,7 @@ ExternalProject_Add(project_libwebsockets
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
+        -DCMAKE_C_FLAGS=${LWS_CMAKE_C_FLAGS}
         -DLWS_WITH_HTTP2=1
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DLWS_HAVE_HMAC_CTX_new=1
@@ -51,6 +50,3 @@ ExternalProject_Add(project_libwebsockets
         BUILD_ALWAYS      TRUE
     TEST_COMMAND      ""
 )
-
-# Revert CMAKE_C_FLAGS afterwards
-set(CMAKE_C_FLAGS "${ORIGINAL_CMAKE_C_FLAGS}")

--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -24,7 +24,7 @@ ExternalProject_Add(project_libwebsockets
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
-        -DDISABLE_WERROR=ON
+        -DDISABLE_WERROR=1
         -DLWS_WITH_HTTP2=1
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DLWS_HAVE_HMAC_CTX_new=1


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Bump the runner images in the GitHub actions configuration file.
- Building with LWS, it was previously working fine on Clang 11. Encountered build issues with the LWS version (3.2.3) on Clang 14, so disable WERROR on the dependency. The GitHub Ubuntu 20 runner (with CC=clang) uses Clang 11 by default, but the latest uses Clang 14 by default.
```
[  8%] Building C object CMakeFiles/websockets_shared.dir/lib/core/libwebsockets.c.o
[ 10%] Building C object CMakeFiles/websockets_shared.dir/lib/core/logs.c.o
[ 11%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/base64-decode.c.o
/home/runner/work/amazon-kinesis-video-streams-producer-c/amazon-kinesis-video-streams-producer-c/open-source/libwebsockets/build/src/project_libwebsockets/lib/misc/base64-decode.c:58:6: error: variable 'line' set but not used [-Werror,-Wunused-but-set-variable]
        int line = 0;
            ^
1 error generated.
gmake[5]: *** [CMakeFiles/websockets_shared.dir/build.make:163: CMakeFiles/websockets_shared.dir/lib/misc/base64-decode.c.o] Error 1
gmake[4]: *** [CMakeFiles/Makefile2:90: CMakeFiles/websockets_shared.dir/all] Error 2
gmake[3]: *** [Makefile:156: all] Error 2
gmake[2]: *** [CMakeFiles/project_libwebsockets.dir/build.make:87: build/src/project_libwebsockets-stamp/project_libwebsockets-build] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/project_libwebsockets.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
CMake Error at CMake/Utilities.cmake:93 (message):
  CMake step for libwebsockets failed: 2
Call Stack (most recent call first):
  CMakeLists.txt:109 (build_dependency)


-- Configuring incomplete, errors occurred!
```

*Why was it changed?*
- macos-12 is deprecated
- Ubuntu 20 will be deprecated sometime in 2025. https://ubuntu.com/about/release-cycle

*How was it changed?*
- See the files changed tab to see which configuration lines were changed.

*What testing was done for the changes?*
- CI should pass.
- Since only the CI was updated, testing on GitHub actions is sufficient.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.