### PR TITLE
Fix Curl Linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,11 +168,11 @@ else()
 endif()
 
 if(BUILD_COMMON_CURL)
+  find_package(CURL REQUIRED)
   if (WIN32)
-    find_package(CURL REQUIRED)
     set(CURL_LIBRARIES CURL::libcurl)
   else()
-    pkg_check_modules(CURL REQUIRED libcurl)
+    set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${CURL_INCLUDE_DIR})
   endif()
 
   set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Replaced `pkg_check_modules` with `find_package` for finding the Curl dependency library.

*Why was it changed?*
- We already use `find_package` for the OpenSSL libraries which points the linker to the correct location for these libraries `/open-source/`.
- Since the Curl being linked was `-lcurl`, it was searched for in the default linker search paths which was finding a different instance of the Curl library installed on the machine.

*How was it changed?*

*What testing was done for the changes?*
- Used `make VERBOSE=1` to see the paths used for linking libraries.
  - Prior to this change:
    `-lcurl -lz ../open-source/local/lib/libssl.a ../open-source/local/lib/libcrypto.a`
  - After this change:
    `test`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.