### PR TITLE
Apply clang-format to the unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,6 @@ on:
       - develop
       - master
 jobs:
-  clang-format-check:
-    runs-on: macos-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install clang-format
-        run: |
-          brew install clang-format
-          clang-format --version
-      - name: Run clang format check
-        run: |
-          bash scripts/check-clang.sh
-
   mac-os-build-gcc:
     runs-on: macos-13
     permissions:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,93 @@
+name: clang-format-check
+on: [ push ]
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-14
+          sudo ln -sf /usr/bin/clang-format-14 /usr/bin/clang-format
+
+      - name: Check clang
+        run: |
+          find . -name "*.c" -o -name "*.h" -o -name "*.cpp" | xargs clang-format -style=file --dry-run -Werror
+        shell: bash
+
+      - name: Clang Format Success Summary
+        if: success()
+        run: |
+          echo "# 🎉 Clang Format Check Passed!" >> $GITHUB_STEP_SUMMARY
+          echo "All files are properly formatted." >> $GITHUB_STEP_SUMMARY
+
+  format-and-upload:
+    runs-on: ubuntu-latest
+    needs: check-format
+    if: failure()  # Only run this job if the check-format job fails
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-14
+          sudo ln -sf /usr/bin/clang-format-14 /usr/bin/clang-format
+
+      - name: Find and format .c, .h, and .cpp files
+        run: |
+          git add -u
+          # Apply formatting
+          find . -name "*.c" -o -name "*.h" -o -name "*.cpp" | xargs clang-format -i -style=file
+          # Check which files were modified by clang-format
+          git diff --name-only > modified_files.txt
+          git diff > clang-format-fix.patch
+          echo "Modified files: $(cat modified_files.txt)"
+        shell: bash
+
+      - name: Archive formatted files
+        run: |
+          mkdir -p formatted_files
+          while IFS= read -r file; do
+            echo "Compressing $file ..."
+            # Copy only modified files to the formatted_files directory, preserving structure
+            mkdir -p "formatted_files/$(dirname "$file")"
+            cp "$file" "formatted_files/$file"
+          done < modified_files.txt
+        shell: bash
+
+      - name: Upload formatted files
+        uses: actions/upload-artifact@v4
+        with:
+          name: formatted-files
+          path: formatted_files
+
+      - name: Upload patch file
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-format-fix.patch
+          path: clang-format-fix.patch
+
+      - name: Generate Markdown Summary for Corrected Files
+        run: |
+          echo "# ❌ Clang Format Check Failed" >> $GITHUB_STEP_SUMMARY
+          echo "$(wc -l < modified_files.txt) file(s) are not clang-format compliant. Please review the list of affected files below:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          while IFS= read -r file; do
+            echo "- \`$file\`" >> $GITHUB_STEP_SUMMARY
+          done < modified_files.txt
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## 🛠️ Fixed files" >> $GITHUB_STEP_SUMMARY
+          echo "**Total Files Formatted**: $(wc -l < modified_files.txt)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "ℹ️ Check the \"Artifacts\" below for the corrected files." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "To apply the formatting fixes locally, download the patch file below and place it in the repository root. Then run this command from the repository root:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "git apply clang-format-fix.patch" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/tst/AuthCallbackTest.cpp
+++ b/tst/AuthCallbackTest.cpp
@@ -1,20 +1,19 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class AuthCallbackTest : public ProducerClientTestBase {
-};
+class AuthCallbackTest : public ProducerClientTestBase {};
 
 TEST_F(AuthCallbackTest, RotatingStaticAuthCallback_ReturnsExtendedExpiration)
 {
-
     // check AWSCredentials is extended by rotation period for stream token function.
-
 }
 
 TEST_F(AuthCallbackTest, ioTExpirationParsing_Returns_Success)
 {
-
     UINT64 iotTimeInEpoch = 1548972059;
     CHAR validFormatIotExpirationTimeStamp[] = "2019-01-31T23:00:59Z"; // expiration is current time + 1 hour
     UINT64 expirationTimestampInEpoch = 0;
@@ -23,24 +22,20 @@ TEST_F(AuthCallbackTest, ioTExpirationParsing_Returns_Success)
 
     EXPECT_TRUE(iotTimeInEpoch == expirationTimestampInEpoch / HUNDREDS_OF_NANOS_IN_A_SECOND - 3600);
 
-    iotTimeInEpoch = 1548975659;   // iot expiration same as current time
+    iotTimeInEpoch = 1548975659; // iot expiration same as current time
 
     convertTimestampToEpoch(validFormatIotExpirationTimeStamp, iotTimeInEpoch, &expirationTimestampInEpoch);
 
     EXPECT_TRUE(iotTimeInEpoch == expirationTimestampInEpoch / HUNDREDS_OF_NANOS_IN_A_SECOND);
 
-    iotTimeInEpoch = 1548975660;   // iot expiration occurs in the past
+    iotTimeInEpoch = 1548975660; // iot expiration occurs in the past
 
     EXPECT_EQ(STATUS_IOT_EXPIRATION_OCCURS_IN_PAST,
-              convertTimestampToEpoch(validFormatIotExpirationTimeStamp,
-                                      iotTimeInEpoch,
-                                      &expirationTimestampInEpoch));
-
+              convertTimestampToEpoch(validFormatIotExpirationTimeStamp, iotTimeInEpoch, &expirationTimestampInEpoch));
 }
 
 TEST_F(AuthCallbackTest, invalidIoTExpirationParsing_Returns_Failure)
 {
-
     UINT64 iotTimeInEpoch = 1548972059;
     UINT64 expirationTimestampInEpoch = 0;
     CHAR invalidIotExpirationTimeStamp[] = "2019-00-31T23:00:59Z";
@@ -51,13 +46,10 @@ TEST_F(AuthCallbackTest, invalidIoTExpirationParsing_Returns_Failure)
               convertTimestampToEpoch(invalidIotExpirationTimeStamp, iotTimeInEpoch, &expirationTimestampInEpoch));
 
     EXPECT_EQ(STATUS_IOT_EXPIRATION_PARSING_FAILED,
-              convertTimestampToEpoch(invalidFormatIotExpirationTimeStamp,
-                                      iotTimeInEpoch,
-                                      &expirationTimestampInEpoch));
+              convertTimestampToEpoch(invalidFormatIotExpirationTimeStamp, iotTimeInEpoch, &expirationTimestampInEpoch));
 
     EXPECT_EQ(STATUS_TIMESTAMP_STRING_UNRECOGNIZED_FORMAT,
               convertTimestampToEpoch(emptyIotExpirationTimestamp, iotTimeInEpoch, &expirationTimestampInEpoch));
-
 }
 
 TEST_F(AuthCallbackTest, verify_fileAuthCallback_provider_works)
@@ -82,19 +74,11 @@ TEST_F(AuthCallbackTest, verify_fileAuthCallback_provider_works)
     EXPECT_EQ(STATUS_SUCCESS, createDefaultDeviceInfo(&pDeviceInfo));
     pDeviceInfo->clientInfo.loggerLogLevel = this->loggerLogLevel;
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     API_CALL_CACHE_TYPE_NONE,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     mRegion,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     mCaCertPath,
-                                                                     NULL,
-                                                                     NULL,
-                                                                     &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createFileAuthCallbacks(pClientCallbacks,
-                                                      authFilePath,
-                                                      &pAuthCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS, createFileAuthCallbacks(pClientCallbacks, authFilePath, &pAuthCallbacks));
 
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
@@ -122,23 +106,13 @@ TEST_F(AuthCallbackTest, credential_provider_auth_callbacks_test)
     streamName[MAX_STREAM_NAME_LEN] = '\0';
     EXPECT_EQ(STATUS_SUCCESS, createDefaultDeviceInfo(&pDeviceInfo));
     pDeviceInfo->clientInfo.loggerLogLevel = this->loggerLogLevel;
-    EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName,
-                                                                    TEST_RETENTION_PERIOD,
-                                                                    TEST_STREAM_BUFFER_DURATION,
-                                                                    &pStreamInfo));
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     API_CALL_CACHE_TYPE_NONE,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     mRegion,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     mCaCertPath,
-                                                                     NULL,
-                                                                     NULL,
-                                                                     &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
 
     // Create the credential provider based on static credentials which will be used with auth callbacks
-    EXPECT_EQ(STATUS_SUCCESS, createStaticCredentialProvider(mAccessKey, 0, mSecretKey, 0, mSessionToken, 0,
-                                                             MAX_UINT64, &pAwsCredentialProvider));
+    EXPECT_EQ(STATUS_SUCCESS, createStaticCredentialProvider(mAccessKey, 0, mSecretKey, 0, mSessionToken, 0, MAX_UINT64, &pAwsCredentialProvider));
 
     // Creating client should fail with missing auth callbacks
     EXPECT_EQ(STATUS_SERVICE_CALL_CALLBACKS_MISSING, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
@@ -161,7 +135,7 @@ TEST_F(AuthCallbackTest, credential_provider_auth_callbacks_test)
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeStaticCredentialProvider(&pAwsCredentialProvider));
 }
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/AwsCredentialsTest.cpp
+++ b/tst/AwsCredentialsTest.cpp
@@ -1,177 +1,70 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class AwsCredentialsTest : public ProducerClientTestBase {
-};
+class AwsCredentialsTest : public ProducerClientTestBase {};
 
 TEST_F(AwsCredentialsTest, createAwsCredentials)
 {
     PAwsCredentials pAwsCredentials = NULL;
     CHAR authStr[MAX_AUTH_LEN + 2];
-    
+
     MEMSET(authStr, 'a', ARRAY_SIZE(authStr));
     authStr[MAX_AUTH_LEN + 1] = '\0';
 
     // Positive case permutations
 
-    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(TEST_ACCESS_KEY, 0, TEST_SECRET_KEY, 0, TEST_SESSION_TOKEN, 0, MAX_UINT64, &pAwsCredentials));
     EXPECT_GE(MAX_AUTH_LEN, pAwsCredentials->size);
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
 
-    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            STRLEN(TEST_ACCESS_KEY),
-            TEST_SECRET_KEY,
-            STRLEN(TEST_SECRET_KEY),
-            TEST_SESSION_TOKEN,
-            STRLEN(TEST_SESSION_TOKEN),
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAwsCredentials(TEST_ACCESS_KEY, STRLEN(TEST_ACCESS_KEY), TEST_SECRET_KEY, STRLEN(TEST_SECRET_KEY), TEST_SESSION_TOKEN,
+                                   STRLEN(TEST_SESSION_TOKEN), MAX_UINT64, &pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
 
-    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            0,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(TEST_ACCESS_KEY, 0, TEST_SECRET_KEY, 0, TEST_SESSION_TOKEN, 0, 0, &pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
 
     // Negative cases
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(
-            EMPTY_STRING,
-            0,
-            EMPTY_STRING,
-            0,
-            EMPTY_STRING,
-            0,
-            0,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(EMPTY_STRING, 0, EMPTY_STRING, 0, EMPTY_STRING, 0, 0, &pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
     EXPECT_EQ(STATUS_SUCCESS, freeAwsCredentials(&pAwsCredentials));
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(
-            EMPTY_STRING,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            0,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(EMPTY_STRING, 0, TEST_SECRET_KEY, 0, TEST_SESSION_TOKEN, 0, 0, &pAwsCredentials));
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(
-            EMPTY_STRING,
-            0,
-            EMPTY_STRING,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            0,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_INVALID_ARG, createAwsCredentials(EMPTY_STRING, 0, EMPTY_STRING, 0, TEST_SESSION_TOKEN, 0, 0, &pAwsCredentials));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(
-            NULL,
-            0,
-            EMPTY_STRING,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            0,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(NULL, 0, EMPTY_STRING, 0, TEST_SESSION_TOKEN, 0, 0, &pAwsCredentials));
 
-
-    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(
-            NULL,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(NULL, 0, TEST_SECRET_KEY, 0, TEST_SESSION_TOKEN, 0, MAX_UINT64, &pAwsCredentials));
     EXPECT_EQ(NULL, pAwsCredentials);
 
-    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            0,
-            NULL,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(TEST_ACCESS_KEY, 0, NULL, 0, TEST_SESSION_TOKEN, 0, MAX_UINT64, &pAwsCredentials));
     EXPECT_EQ(NULL, pAwsCredentials);
 
-    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createAwsCredentials(
-            authStr,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createAwsCredentials(authStr, 0, TEST_SECRET_KEY, 0, TEST_SESSION_TOKEN, 0, MAX_UINT64, &pAwsCredentials));
     EXPECT_EQ(NULL, pAwsCredentials);
 
-    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            0,
-            authStr,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createAwsCredentials(TEST_ACCESS_KEY, 0, authStr, 0, TEST_SESSION_TOKEN, 0, MAX_UINT64, &pAwsCredentials));
     EXPECT_EQ(NULL, pAwsCredentials);
 
-    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            authStr,
-            0,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createAwsCredentials(TEST_ACCESS_KEY, 0, TEST_SECRET_KEY, 0, authStr, 0, MAX_UINT64, &pAwsCredentials));
     EXPECT_EQ(NULL, pAwsCredentials);
 
-    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            MAX_AUTH_LEN / 3,
-            TEST_SECRET_KEY,
-            MAX_AUTH_LEN / 3,
-            TEST_SESSION_TOKEN,
-            MAX_AUTH_LEN / 3,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_INVALID_AUTH_LEN,
+              createAwsCredentials(TEST_ACCESS_KEY, MAX_AUTH_LEN / 3, TEST_SECRET_KEY, MAX_AUTH_LEN / 3, TEST_SESSION_TOKEN, MAX_AUTH_LEN / 3,
+                                   MAX_UINT64, &pAwsCredentials));
     EXPECT_EQ(NULL, pAwsCredentials);
 
-    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            MAX_UINT64,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, createAwsCredentials(TEST_ACCESS_KEY, 0, TEST_SECRET_KEY, 0, TEST_SESSION_TOKEN, 0, MAX_UINT64, NULL));
 }
 
 TEST_F(AwsCredentialsTest, freeAwsCredentials)
@@ -188,15 +81,7 @@ TEST_F(AwsCredentialsTest, deserializeAwsCredentials)
     EXPECT_EQ(STATUS_NULL_ARG, deserializeAwsCredentials(NULL));
 
     // Create valid credentials, roundtrip.
-    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(
-            TEST_ACCESS_KEY,
-            0,
-            TEST_SECRET_KEY,
-            0,
-            TEST_SESSION_TOKEN,
-            0,
-            MAX_UINT64,
-            &pAwsCredentials));
+    EXPECT_EQ(STATUS_SUCCESS, createAwsCredentials(TEST_ACCESS_KEY, 0, TEST_SECRET_KEY, 0, TEST_SESSION_TOKEN, 0, MAX_UINT64, &pAwsCredentials));
 
     // Copy forward the bits
     MEMCPY(tempBuff, pAwsCredentials, pAwsCredentials->size);
@@ -232,7 +117,8 @@ TEST_F(AwsCredentialsTest, deserializeAwsCredentials)
     pDeserialized->sessionToken = pStored;
 }
 
-TEST_F(AwsCredentialsTest, TestFileCredentialsWriteWithoutSession) {
+TEST_F(AwsCredentialsTest, TestFileCredentialsWriteWithoutSession)
+{
     PAwsCredentialProvider pAwsCredentialProvider = NULL;
     CHAR fileContent[10000];
     UINT32 length = ARRAY_SIZE(fileContent);
@@ -247,7 +133,8 @@ TEST_F(AwsCredentialsTest, TestFileCredentialsWriteWithoutSession) {
     EXPECT_EQ(STATUS_SUCCESS, freeFileCredentialProvider(&pAwsCredentialProvider));
 }
 
-TEST_F(AwsCredentialsTest, TestFileCredentialsWriteWithSession) {
+TEST_F(AwsCredentialsTest, TestFileCredentialsWriteWithSession)
+{
     PAwsCredentialProvider pAwsCredentialProvider = NULL;
     CHAR fileContent[10000];
     UINT32 length = ARRAY_SIZE(fileContent);
@@ -262,7 +149,7 @@ TEST_F(AwsCredentialsTest, TestFileCredentialsWriteWithSession) {
     EXPECT_EQ(STATUS_SUCCESS, freeFileCredentialProvider(&pAwsCredentialProvider));
 }
 
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/CallbacksProviderApiTest.cpp
+++ b/tst/CallbacksProviderApiTest.cpp
@@ -1,257 +1,122 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class CallbacksProviderApiTest : public ProducerClientTestBase {
-};
+class CallbacksProviderApiTest : public ProducerClientTestBase {};
 
 TEST_F(CallbacksProviderApiTest, createDefaultCallbacksProvider_variations)
 {
     PClientCallbacks pClientCallbacks = NULL;
-    EXPECT_NE(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             NULL));
+    EXPECT_NE(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, NULL));
     EXPECT_NE(STATUS_SUCCESS, freeCallbacksProvider(NULL));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_NE(STATUS_SUCCESS, createDefaultCallbacksProvider(MAX_CALLBACK_CHAIN_COUNT + 1,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_NE(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(MAX_CALLBACK_CHAIN_COUNT + 1, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE(STATUS_SUCCESS, freeCallbacksProvider(NULL));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_NE(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             MAX_ENDPOINT_CACHE_UPDATE_PERIOD + 1,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_NE(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, MAX_ENDPOINT_CACHE_UPDATE_PERIOD + 1, TRUE,
+                                             &pClientCallbacks));
     EXPECT_NE(STATUS_SUCCESS, freeCallbacksProvider(NULL));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_NE(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_ENDPOINT_ONLY,
-                                                             MAX_ENDPOINT_CACHE_UPDATE_PERIOD + 1,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_NE(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_ENDPOINT_ONLY, MAX_ENDPOINT_CACHE_UPDATE_PERIOD + 1, TRUE,
+                                             &pClientCallbacks));
     EXPECT_NE(STATUS_SUCCESS, freeCallbacksProvider(NULL));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_ENDPOINT_ONLY,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_ENDPOINT_ONLY, TEST_CACHING_ENDPOINT_PERIOD, TRUE,
+                                             &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             FALSE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, FALSE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             NULL,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, NULL, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, TEST_USER_AGENT,
+                                             API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             NULL,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, NULL, mCaCertPath, NULL, TEST_USER_AGENT,
+                                             API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             TEST_USER_AGENT,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             TEST_DEFAULT_REGION,
-                                                             TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath,
-                                                             NULL,
-                                                             NULL,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL,
+                                             API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             NULL,
-                                                             NULL,
-                                                             NULL,
-                                                             NULL,
-                                                             NULL,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, NULL, NULL, NULL, NULL, NULL, API_CALL_CACHE_TYPE_NONE,
+                                             TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             API_CALL_CACHE_TYPE_NONE,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+                                             API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                             TEST_ACCESS_KEY,
-                                                             TEST_SECRET_KEY,
-                                                             TEST_SESSION_TOKEN,
-                                                             TEST_STREAMING_TOKEN_DURATION,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             EMPTY_STRING,
-                                                             API_CALL_CACHE_TYPE_ENDPOINT_ONLY,
-                                                             TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE,
-                                                             &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+                                             API_CALL_CACHE_TYPE_ENDPOINT_ONLY, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
@@ -274,25 +139,13 @@ TEST_F(CallbacksProviderApiTest, createStreamVerifyCallbackChainIntegration)
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
     pStreamInfo->streamCaps.nalAdaptationFlags = NAL_ADAPTATION_FLAG_NONE;
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createAbstractDefaultCallbacksProvider(MAX_CALLBACK_CHAIN_COUNT + 1,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         mRegion,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         mCaCertPath,
-                                                                         NULL,
-                                                                         NULL,
-                                                                         &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              createAbstractDefaultCallbacksProvider(MAX_CALLBACK_CHAIN_COUNT + 1, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     API_CALL_CACHE_TYPE_NONE,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     mRegion,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     mCaCertPath,
-                                                                     NULL,
-                                                                     NULL,
-                                                                     &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
 
     mApiCallbacks.version = API_CALLBACKS_CURRENT_VERSION;
     mApiCallbacks.customData = (UINT64) this;
@@ -317,13 +170,9 @@ TEST_F(CallbacksProviderApiTest, createStreamVerifyCallbackChainIntegration)
 
     UINT64 expiration = currentTime + TEST_STREAMING_TOKEN_DURATION;
     PAuthCallbacks pAuthCallbacks;
-    EXPECT_EQ(STATUS_SUCCESS, createRotatingStaticAuthCallbacks(pClientCallbacks,
-                                                                mAccessKey,
-                                                                mSecretKey,
-                                                                mSessionToken,
-                                                                expiration,
-                                                                TEST_STREAMING_TOKEN_DURATION,
-                                                                &pAuthCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRotatingStaticAuthCallbacks(pClientCallbacks, mAccessKey, mSecretKey, mSessionToken, expiration, TEST_STREAMING_TOKEN_DURATION,
+                                                &pAuthCallbacks));
 
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
@@ -357,25 +206,13 @@ TEST_F(CallbacksProviderApiTest, createStreamVerifyCallbackChainStopsOnStopStatu
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
     pStreamInfo->streamCaps.nalAdaptationFlags = NAL_ADAPTATION_FLAG_NONE;
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createAbstractDefaultCallbacksProvider(MAX_CALLBACK_CHAIN_COUNT + 1,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         mRegion,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         mCaCertPath,
-                                                                         NULL,
-                                                                         NULL,
-                                                                         &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              createAbstractDefaultCallbacksProvider(MAX_CALLBACK_CHAIN_COUNT + 1, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     API_CALL_CACHE_TYPE_NONE,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     mRegion,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     mCaCertPath,
-                                                                     NULL,
-                                                                     NULL,
-                                                                     &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
 
     mApiCallbacks.version = API_CALLBACKS_CURRENT_VERSION;
     mApiCallbacks.customData = (UINT64) this;
@@ -400,13 +237,9 @@ TEST_F(CallbacksProviderApiTest, createStreamVerifyCallbackChainStopsOnStopStatu
 
     UINT64 expiration = currentTime + TEST_STREAMING_TOKEN_DURATION;
     PAuthCallbacks pAuthCallbacks;
-    EXPECT_EQ(STATUS_SUCCESS, createRotatingStaticAuthCallbacks(pClientCallbacks,
-                                                                mAccessKey,
-                                                                mSecretKey,
-                                                                mSessionToken,
-                                                                expiration,
-                                                                TEST_STREAMING_TOKEN_DURATION,
-                                                                &pAuthCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRotatingStaticAuthCallbacks(pClientCallbacks, mAccessKey, mSecretKey, mSessionToken, expiration, TEST_STREAMING_TOKEN_DURATION,
+                                                &pAuthCallbacks));
 
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
@@ -423,7 +256,7 @@ TEST_F(CallbacksProviderApiTest, createStreamVerifyCallbackChainStopsOnStopStatu
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 }
 
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/CallbacksProviderPublicApiTest.cpp
+++ b/tst/CallbacksProviderPublicApiTest.cpp
@@ -1,579 +1,255 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class CallbacksProviderPublicApiTest : public ProducerClientTestBase {
-};
+class CallbacksProviderPublicApiTest : public ProducerClientTestBase {};
 
 TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithIotCertificate)
 {
     PClientCallbacks pClientCallbacks;
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH,
+                                                               TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                                                               (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificate(
+                  TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                  (PCHAR) DEFAULT_AWS_REGION, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH,
+                                                               TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                                                               (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, NULL));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificate(
-            NULL,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificate(NULL, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH,
+                                                               TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL,
+                                                               &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            NULL,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, NULL, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH,
+                                                               TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL,
+                                                               &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            NULL,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, NULL, TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS,
+                                                               TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            NULL,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_ROLE_ALIAS, NULL, TEST_IOT_ROLE_ALIAS,
+                                                               TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_CA_CERT_PATH,
-            NULL,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_CA_CERT_PATH, NULL,
+                                                               TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            NULL,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_CA_CERT_PATH,
+                                                               TEST_IOT_ROLE_ALIAS, NULL, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificate(
-            EMPTY_STRING,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificate(EMPTY_STRING, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH,
+                                                               TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL,
+                                                               &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            EMPTY_STRING,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, EMPTY_STRING, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH,
+                                                               TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL,
+                                                               &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            EMPTY_STRING,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, EMPTY_STRING, TEST_CA_CERT_PATH,
+                                                               TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL,
+                                                               &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED, createDefaultCallbacksProviderWithIotCertificate(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            EMPTY_STRING,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED,
+              createDefaultCallbacksProviderWithIotCertificate(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH, EMPTY_STRING,
+                                                               TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL, NULL,
+                                                               &pClientCallbacks));
 }
 
 TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithIotCertificateAndTimeouts)
 {
     PClientCallbacks pClientCallbacks;
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH,
+                                                                          TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                                                                          (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
+                  TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                  (PCHAR) DEFAULT_AWS_REGION, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH,
+                                                                          TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                                                                          (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, 1, 2, NULL));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            NULL,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(NULL, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH,
+                                                                          TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL,
+                                                                          NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            NULL,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, NULL, TEST_IOT_CERT_PRIVATE_KEY_PATH, TEST_CA_CERT_PATH,
+                                                                          TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL,
+                                                                          NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            NULL,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, NULL, TEST_CA_CERT_PATH,
+                                                                          TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL,
+                                                                          NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            NULL,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_ROLE_ALIAS, NULL,
+                                                                          TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL,
+                                                                          NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_CA_CERT_PATH,
-            NULL,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_ROLE_ALIAS,
+                                                                          TEST_CA_CERT_PATH, NULL, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION,
+                                                                          NULL, NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            NULL,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_ROLE_ALIAS,
+                                                                          TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, NULL, (PCHAR) DEFAULT_AWS_REGION,
+                                                                          NULL, NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            EMPTY_STRING,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(EMPTY_STRING, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH,
+                                                                          TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                                                                          (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            EMPTY_STRING,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, EMPTY_STRING, TEST_IOT_CERT_PRIVATE_KEY_PATH,
+                                                                          TEST_CA_CERT_PATH, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                                                                          (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            EMPTY_STRING,
-            TEST_CA_CERT_PATH,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_DIRECTORY_ENTRY_STAT_ERROR,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, EMPTY_STRING, TEST_CA_CERT_PATH,
+                                                                          TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME, (PCHAR) DEFAULT_AWS_REGION, NULL,
+                                                                          NULL, 1, 2, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED, createDefaultCallbacksProviderWithIotCertificateAndTimeouts(
-            TEST_IOT_ENDPOINT,
-            TEST_IOT_CERT_PATH,
-            TEST_IOT_CERT_PRIVATE_KEY_PATH,
-            EMPTY_STRING,
-            TEST_IOT_ROLE_ALIAS,
-            TEST_IOT_THING_NAME,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            NULL,
-            1,
-            2,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_CURL_PERFORM_FAILED,
+              createDefaultCallbacksProviderWithIotCertificateAndTimeouts(TEST_IOT_ENDPOINT, TEST_IOT_CERT_PATH, TEST_IOT_CERT_PRIVATE_KEY_PATH,
+                                                                          EMPTY_STRING, TEST_IOT_ROLE_ALIAS, TEST_IOT_THING_NAME,
+                                                                          (PCHAR) DEFAULT_AWS_REGION, NULL, NULL, 1, 2, &pClientCallbacks));
 }
 
 TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAwsCredentials)
 {
     PClientCallbacks pClientCallbacks = NULL;
     CHAR authStr[MAX_AUTH_LEN + 2];
-    
+
     MEMSET(authStr, 'a', ARRAY_SIZE(authStr));
     authStr[MAX_AUTH_LEN + 1] = '\0';
 
     // Positive case permutations
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64,
+                                                               (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                               TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     // Idempotent call
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            NULL,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, NULL, MAX_UINT64, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            EMPTY_STRING,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, EMPTY_STRING, MAX_UINT64, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            NULL,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64,
+                                                               (PCHAR) DEFAULT_AWS_REGION, NULL, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT,
+                                                               &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            NULL,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64,
+                                                               (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, NULL, TEST_USER_AGENT,
+                                                               &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64,
+                                                               (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, NULL,
+                                                               &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            NULL,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64, NULL,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
-            EMPTY_STRING,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              createDefaultCallbacksProviderWithAwsCredentials(EMPTY_STRING, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64,
+                                                               (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                               TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            EMPTY_STRING,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, EMPTY_STRING, TEST_SESSION_TOKEN, MAX_UINT64,
+                                                               (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                               TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            0,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN, 0, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
     // Negative case permutations
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAwsCredentials(
-            NULL,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithAwsCredentials(NULL, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            NULL,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, NULL, TEST_SESSION_TOKEN, MAX_UINT64, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createDefaultCallbacksProviderWithAwsCredentials(
-            authStr,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_AUTH_LEN,
+              createDefaultCallbacksProviderWithAwsCredentials(authStr, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            authStr,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_AUTH_LEN,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, authStr, TEST_SESSION_TOKEN, MAX_UINT64, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_INVALID_AUTH_LEN, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            authStr,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_AUTH_LEN,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, authStr, MAX_UINT64, (PCHAR) DEFAULT_AWS_REGION,
+                                                               TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX, TEST_USER_AGENT, &pClientCallbacks));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAwsCredentials(
-            TEST_ACCESS_KEY,
-            TEST_SECRET_KEY,
-            TEST_SESSION_TOKEN,
-            MAX_UINT64,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithAwsCredentials(TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN, MAX_UINT64,
+                                                               (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                               TEST_USER_AGENT, NULL));
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAwsCredentials(
-            NULL,
-            NULL,
-            NULL,
-            MAX_UINT64,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAwsCredentials(NULL, NULL, NULL, MAX_UINT64, NULL, NULL, NULL, NULL, NULL));
 }
 
 TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithFileAuth)
@@ -585,31 +261,19 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithFileAut
     MEMSET(filePath, 'a', ARRAY_SIZE(filePath));
     filePath[MAX_PATH_LEN + 1] = '\0';
 
-    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED, createDefaultCallbacksProviderWithFileAuth(
-            TEST_AUTH_FILE_PATH,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED,
+              createDefaultCallbacksProviderWithFileAuth(TEST_AUTH_FILE_PATH, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                         TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithFileAuth(
-            TEST_AUTH_FILE_PATH,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithFileAuth(TEST_AUTH_FILE_PATH, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                         TEST_USER_AGENT, NULL));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_INVALID_ARG, createDefaultCallbacksProviderWithFileAuth(
-            filePath,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              createDefaultCallbacksProviderWithFileAuth(filePath, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                         TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
     // Try max file length
@@ -617,13 +281,9 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithFileAut
     MEMSET(fileContent, 'a', ARRAY_SIZE(fileContent));
     ASSERT_EQ(STATUS_SUCCESS, writeFile(filePath, FALSE, FALSE, (PBYTE) fileContent, ARRAY_SIZE(fileContent)));
 
-    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH, createDefaultCallbacksProviderWithFileAuth(
-            filePath,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH,
+              createDefaultCallbacksProviderWithFileAuth(filePath, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                         TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
     // Try bad content creds file
@@ -631,13 +291,9 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithFileAut
     STRCPY(fileContent, "Bad creds file");
     ASSERT_EQ(STATUS_SUCCESS, writeFile(filePath, FALSE, FALSE, (PBYTE) fileContent, STRLEN(fileContent)));
 
-    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT, createDefaultCallbacksProviderWithFileAuth(
-            filePath,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT,
+              createDefaultCallbacksProviderWithFileAuth(filePath, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                         TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 }
 
@@ -666,154 +322,103 @@ TEST_F(CallbacksProviderPublicApiTest, createDefaultCallbacksProviderWithAuthCal
 
     // Positive cases
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
     pStored = (PVOID) pAuthCallbacks->getDeviceCertificateFn;
     pAuthCallbacks->getDeviceCertificateFn = NULL;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     pAuthCallbacks->getDeviceCertificateFn = (GetDeviceCertificateFunc) pStored;
 
     pStored = (PVOID) pAuthCallbacks->getStreamingTokenFn;
     pAuthCallbacks->getStreamingTokenFn = NULL;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     pAuthCallbacks->getStreamingTokenFn = (GetStreamingTokenFunc) pStored;
 
     pStored = (PVOID) pAuthCallbacks->getDeviceFingerprintFn;
     pAuthCallbacks->getDeviceFingerprintFn = NULL;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     pAuthCallbacks->getDeviceFingerprintFn = (GetDeviceFingerprintFunc) pStored;
 
     pStored = (PVOID) pAuthCallbacks->deviceCertToTokenFn;
     pAuthCallbacks->deviceCertToTokenFn = NULL;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     pAuthCallbacks->deviceCertToTokenFn = (DeviceCertToTokenFunc) pStored;
 
     pStored = (PVOID) pAuthCallbacks->getSecurityTokenFn;
     pAuthCallbacks->getSecurityTokenFn = NULL;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     pAuthCallbacks->getSecurityTokenFn = (GetSecurityTokenFunc) pStored;
 
     pStored = (PVOID) pAuthCallbacks->freeAuthCallbacksFn;
     pAuthCallbacks->freeAuthCallbacksFn = NULL;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     pAuthCallbacks->freeAuthCallbacksFn = (FreeAuthCallbacksFunc) pStored;
 
     pStored = (PVOID) pAuthCallbacks->freeAuthCallbacksFn;
-    pAuthCallbacks->freeAuthCallbacksFn = [] (PUINT64 ptr) -> STATUS {
+    pAuthCallbacks->freeAuthCallbacksFn = [](PUINT64 ptr) -> STATUS {
         UNUSED_PARAM(ptr);
         return STATUS_INVALID_ARG;
     };
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_NE((PClientCallbacks) NULL, pClientCallbacks);
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     pAuthCallbacks->freeAuthCallbacksFn = (FreeAuthCallbacksFunc) pStored;
 
     // Negative cases
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAuthCallbacks(
-            NULL,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithAuthCallbacks(NULL, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, NULL));
     EXPECT_EQ(NULL, pClientCallbacks);
 
-    EXPECT_EQ(STATUS_NULL_ARG, createDefaultCallbacksProviderWithAuthCallbacks(
-            NULL,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            NULL));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createDefaultCallbacksProviderWithAuthCallbacks(NULL, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, NULL));
     EXPECT_EQ(NULL, pClientCallbacks);
 
     pAuthCallbacks->version = AUTH_CALLBACKS_CURRENT_VERSION + 1;
-    EXPECT_EQ(STATUS_INVALID_AUTH_CALLBACKS_VERSION, createDefaultCallbacksProviderWithAuthCallbacks(
-            pAuthCallbacks,
-            (PCHAR) DEFAULT_AWS_REGION,
-            TEST_CA_CERT_PATH,
-            TEST_USER_AGENT_POSTFIX,
-            TEST_USER_AGENT,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_INVALID_AUTH_CALLBACKS_VERSION,
+              createDefaultCallbacksProviderWithAuthCallbacks(pAuthCallbacks, (PCHAR) DEFAULT_AWS_REGION, TEST_CA_CERT_PATH, TEST_USER_AGENT_POSTFIX,
+                                                              TEST_USER_AGENT, &pClientCallbacks));
     pAuthCallbacks->version = AUTH_CALLBACKS_CURRENT_VERSION;
-
-
-
 }
 
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/FileLoggerFunctionalityTest.cpp
+++ b/tst/FileLoggerFunctionalityTest.cpp
@@ -1,744 +1,734 @@
 #include "ProducerTestFixture.h"
 
 // length of time and log level string in log: "2019-11-09 19:11:16.xxx VERBOSE "
-#define TIMESTRING_OFFSET               32
+#define TIMESTRING_OFFSET 32
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-    class FileLoggerFunctionalityTest : public ProducerClientTestBase
+class FileLoggerFunctionalityTest : public ProducerClientTestBase {
+  public:
+    FileLoggerFunctionalityTest() : ProducerClientTestBase()
     {
-        public:
-            FileLoggerFunctionalityTest() :  ProducerClientTestBase() {
-                // Tests will fail if log level is not warn
-                SET_LOGGER_LOG_LEVEL(LOG_LEVEL_WARN);
-            }
-    };
-
-    TEST_F(FileLoggerFunctionalityTest, basicFileLoggerUsage)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-        UINT64 currentFileIndex = 0;
-        CHAR fileIndexBuffer[256];
-        UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         TEST_DEFAULT_REGION,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         EMPTY_STRING,
-                                                                         NULL,
-                                                                         TEST_USER_AGENT,
-                                                                         &pClientCallbacks));
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-
-        EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE));
-        logFunc = pClientCallbacks->logPrintFn;
-
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        // low log level logs have no effect
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should not have been flushed because we havent fill out string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound); // index file should not be there
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed because the new message overflows string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        // second log is still in buffer. Thus this log will cause the second log to be flushed.
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // index file should be there
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
-        fileIndexBuffer[fileIndexBufferSize] = '\0';
-        STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
-        EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
-
-        MEMFREE(logMessage);
+        // Tests will fail if log level is not warn
+        SET_LOGGER_LOG_LEVEL(LOG_LEVEL_WARN);
     }
-
-    TEST_F(FileLoggerFunctionalityTest, checkFileRotation)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2, i = 0, logIterationCount = 12, logFileCount = 0, maxLogFileCount = 5;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-        CHAR filePath[MAX_PATH_LEN];
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         TEST_DEFAULT_REGION,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         EMPTY_STRING,
-                                                                         NULL,
-                                                                         TEST_USER_AGENT,
-                                                                         &pClientCallbacks));
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        for(; i < logIterationCount; ++i) {
-            SNPRINTF(filePath, MAX_PATH_LEN, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
-            FREMOVE(filePath);
-        }
-
-        EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, maxLogFileCount, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE));
-        logFunc = pClientCallbacks->logPrintFn;
-
-        // should create 12 files if limit allows
-        for(i = 0; i < logIterationCount; ++i) {
-            logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        }
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-        for(i = 0; i < logIterationCount; ++i) {
-            SNPRINTF(filePath, MAX_PATH_LEN, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
-            EXPECT_EQ(STATUS_SUCCESS, fileExists(filePath, &fileFound));
-            // only log file with index from 6 to 11 should remain. The rest are rotated out.
-            if (i < logIterationCount && i >= (logIterationCount - maxLogFileCount)) {
-                EXPECT_EQ(TRUE, fileFound);
-                logFileCount++;
-            } else {
-                EXPECT_EQ(FALSE, fileFound);
-            }
-        }
-
-        EXPECT_EQ(maxLogFileCount, logFileCount);
-
-        MEMFREE(logMessage);
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, fileLoggerPicksUpFromLastFileIndex)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2, fileIndexStrSize = 256;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-        UINT64 currentFileIndex = 0;
-        CHAR fileIndexBuffer[256];
-        UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         TEST_DEFAULT_REGION,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         EMPTY_STRING,
-                                                                         NULL,
-                                                                         TEST_USER_AGENT,
-                                                                         &pClientCallbacks));
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-
-        ULLTOSTR(128, fileIndexBuffer, ARRAY_SIZE(fileIndexBuffer), 10, &fileIndexStrSize);
-        EXPECT_EQ(STATUS_SUCCESS, writeFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, FALSE, (PBYTE) fileIndexBuffer, STRLEN(fileIndexBuffer) * SIZEOF(CHAR)));
-
-        EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE));
-        logFunc = pClientCallbacks->logPrintFn;
-
-        // Cause a log flush.
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-
-        // check that log file name follows last index
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".128"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // index file should be there
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-        // remaining log get flushed
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".129"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
-        fileIndexBuffer[fileIndexBufferSize] = '\0';
-        STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
-        EXPECT_EQ(130, currentFileIndex); // index should be incremented 3 times
-
-        MEMFREE(logMessage);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME ".128");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME ".129");
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, logMessageLongerThanStringBuffer)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE + 100, i;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        PCHAR fileBuffer = (PCHAR) MEMALLOC(logMessageSize + 1);
-        UINT64 fileBufferLen = logMessageSize + 1;
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-
-        EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         TEST_DEFAULT_REGION,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         EMPTY_STRING,
-                                                                         NULL,
-                                                                         TEST_USER_AGENT,
-                                                                         &pClientCallbacks));
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        // everthing starting from i should be truncated. So there should be no b in the log file.
-        // minus - 1 because vsnprintf prints at most MIN_FILE_LOGGER_STRING_BUFFER_SIZE - 1 chars.
-        for (i = MIN_FILE_LOGGER_STRING_BUFFER_SIZE - TIMESTRING_OFFSET - 1; i < logMessageSize; ++i) {
-            logMessage[i] = 'b';
-        }
-
-        EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE));
-        logFunc = pClientCallbacks->logPrintFn;
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-        // no log should be produced as the only log message was dropped because it was too long.
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), TRUE, NULL, &fileBufferLen));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), TRUE, (PBYTE) fileBuffer, &fileBufferLen));
-        fileBuffer[fileBufferLen] = '\0';
-
-        EXPECT_EQ('a', fileBuffer[STRLEN(fileBuffer) - 1]); // there should be no b in the log.
-
-        MEMFREE(logMessage);
-        MEMFREE(fileBuffer);
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, oldLogFileOverrittenByFlushTriggerredByNewLog)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        PCHAR fileBuffer = (PCHAR) MEMALLOC(MIN_FILE_LOGGER_STRING_BUFFER_SIZE);
-        UINT64 fileBufferLen = MIN_FILE_LOGGER_STRING_BUFFER_SIZE;
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         TEST_DEFAULT_REGION,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         EMPTY_STRING,
-                                                                         NULL,
-                                                                         TEST_USER_AGENT,
-                                                                         &pClientCallbacks));
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3");
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-
-        EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 3, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE));
-        logFunc = pClientCallbacks->logPrintFn;
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        MEMSET(logMessage, 'b', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-
-        // kvsProducerLog.0 is deleted
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3"), TRUE, NULL, &fileBufferLen));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3"), TRUE, (PBYTE) fileBuffer, &fileBufferLen));
-        fileBuffer[fileBufferLen] = '\0';
-        // skip over the timestamp string
-        // use STRNCMP to not catch the newline at the end of fileBuffer
-        EXPECT_EQ(0, STRNCMP(logMessage, fileBuffer + TIMESTRING_OFFSET, STRLEN(logMessage)));
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-        MEMFREE(logMessage);
-        MEMFREE(fileBuffer);
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, oldLogFileOverrittenByFlushTriggerredByFreeCallbacks)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        PCHAR fileBuffer = (PCHAR) MEMALLOC(MIN_FILE_LOGGER_STRING_BUFFER_SIZE);
-        UINT64 fileBufferLen = MIN_FILE_LOGGER_STRING_BUFFER_SIZE;
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         TEST_DEFAULT_REGION,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         EMPTY_STRING,
-                                                                         NULL,
-                                                                         TEST_USER_AGENT,
-                                                                         &pClientCallbacks));
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-
-        EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 1, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE));
-        logFunc = pClientCallbacks->logPrintFn;
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-
-        MEMSET(logMessage, 'b', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), TRUE, NULL, &fileBufferLen));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), TRUE, (PBYTE) fileBuffer, &fileBufferLen));
-        fileBuffer[fileBufferLen] = '\0';
-
-        // skip over the timestamp string
-        // use STRNCMP to not catch the newline at the end of fileBuffer
-        EXPECT_EQ(0, STRNCMP(logMessage, fileBuffer + TIMESTRING_OFFSET, STRLEN(logMessage)));
-
-        MEMFREE(logMessage);
-        MEMFREE(fileBuffer);
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaCallbackNoGlobalLog)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-        UINT64 currentFileIndex = 0;
-        CHAR fileIndexBuffer[256];
-        UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-
-        EXPECT_EQ(STATUS_SUCCESS, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, FALSE, &logFunc));
-
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        // low log level logs have no effect
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should not have been flushed because we havent fill out string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound); // index file should not be there
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed because the new message overflows string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        // second log is still in buffer. Thus this log will cause the second log to be flushed.
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // index file should be there
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
-        fileIndexBuffer[fileIndexBufferSize] = '\0';
-        STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
-        EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
-
-        EXPECT_EQ(STATUS_SUCCESS, freeFileLogger());
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
-
-        MEMFREE(logMessage);
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaCallbackWithGlobalLog)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-        UINT64 currentFileIndex = 0;
-        CHAR fileIndexBuffer[256];
-        UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-
-        EXPECT_EQ(STATUS_SUCCESS, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, TRUE, &logFunc));
-
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        // low log level logs have no effect
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should not have been flushed because we havent fill out string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound); // index file should not be there
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed because the new message overflows string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        // second log is still in buffer. Thus this log will cause the second log to be flushed.
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // index file should be there
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
-        fileIndexBuffer[fileIndexBufferSize] = '\0';
-        STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
-        EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
-
-        EXPECT_EQ(STATUS_SUCCESS, freeFileLogger());
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
-
-        MEMFREE(logMessage);
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaGlobalLog)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        UINT64 currentFileIndex = 0;
-        CHAR fileIndexBuffer[256];
-        UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-
-        EXPECT_EQ(STATUS_SUCCESS, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, TRUE, NULL));
-
-        DLOGV("%s", logMessage);
-        DLOGV("%s", logMessage);
-        // low log level logs have no effect
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        DLOGE("%s", logMessage);
-        // log should not have been flushed because we havent fill out string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound); // index file should not be there
-
-        DLOGE("%s", logMessage);
-        // log should have been flushed because the new message overflows string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        // second log is still in buffer. Thus this log will cause the second log to be flushed.
-        DLOGE("%s", logMessage);
-        // log should have been flushed
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // index file should be there
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
-        fileIndexBuffer[fileIndexBufferSize] = '\0';
-        STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
-        EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
-
-        EXPECT_EQ(STATUS_SUCCESS, freeFileLogger());
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
-
-        MEMFREE(logMessage);
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaGlobalLogSetResetMacros)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        UINT64 currentFileIndex = 0;
-        CHAR fileIndexBuffer[256];
-        UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-
-        // make sure the files dont exist
-        FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-
-        EXPECT_EQ(STATUS_SUCCESS, SET_FILE_LOGGER());
-
-        DLOGE("%s", logMessage);
-        // log should not have been flushed because we havent fill out string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound); // index file should not be there
-
-        EXPECT_EQ(STATUS_SUCCESS, RESET_FILE_LOGGER());
-
-        // log should not have been flushed because we havent fill out string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        MEMFREE(logMessage);
-
-        // Ensure we can still log err
-        DLOGE("Printout after reset");
-    }
-
-    TEST_F(FileLoggerFunctionalityTest, basicFilterFileLoggerUsage)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
-        PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
-        BOOL fileFound = FALSE;
-        LogPrintFunc logFunc;
-        UINT64 currentFileIndex = 0;
-        CHAR fileIndexBuffer[256];
-        UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
-
-        MEMSET(logMessage, 'a', logMessageSize);
-        logMessage[logMessageSize] = '\0';
-        EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                         API_CALL_CACHE_TYPE_NONE,
-                                                                         TEST_CACHING_ENDPOINT_PERIOD,
-                                                                         TEST_DEFAULT_REGION,
-                                                                         TEST_CONTROL_PLANE_URI,
-                                                                         EMPTY_STRING,
-                                                                         NULL,
-                                                                         TEST_USER_AGENT,
-                                                                         &pClientCallbacks));
-
-        // make sure the files dont exist
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
-
-        EXPECT_EQ(STATUS_SUCCESS, addFileLoggerWithFilteringPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, TRUE, LOG_LEVEL_WARN));
-        logFunc = pClientCallbacks->logPrintFn;
-
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
-        // low log level logs have no effect
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should not have been flushed because we havent fill out string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound); // index file should not be there
-
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed because the new message overflows string buffer
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // index file should not be there
-
-        // second log is still in buffer. Thus this log will cause the second log to be flushed.
-        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
-        // log should have been flushed
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound); // index file should be there
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
-        fileIndexBuffer[fileIndexBufferSize] = '\0';
-        STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
-        EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
-
-        logFunc(LOG_LEVEL_WARN, NULL, (PCHAR) "%s", logMessage);
-
-        // We would still not see the log file flushed because the file is not filled
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(FALSE, fileFound);
-
-        logFunc(LOG_LEVEL_WARN, NULL, (PCHAR) "%s", logMessage);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        logFunc(LOG_LEVEL_WARN, NULL, (PCHAR) "%s", logMessage);
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-        // Expect new log filter file to be created despite log file not being filled because we release the file logger
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".1"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        // remaining log get flushed when callbacks are freed.
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
-        EXPECT_EQ(TRUE, fileFound);
-
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
-        EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
-        fileIndexBuffer[fileIndexBufferSize] = '\0';
-        STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
-        EXPECT_EQ(3, currentFileIndex); // index should be 3 since we flushed twice.
-
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME);
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".1");
-        FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".2");
-
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-        MEMFREE(logMessage);
-    }
+};
+
+TEST_F(FileLoggerFunctionalityTest, basicFileLoggerUsage)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+    UINT64 currentFileIndex = 0;
+    CHAR fileIndexBuffer[256];
+    UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR,
+                                                     FALSE));
+    logFunc = pClientCallbacks->logPrintFn;
+
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    // low log level logs have no effect
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should not have been flushed because we havent fill out string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound); // index file should not be there
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed because the new message overflows string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    // second log is still in buffer. Thus this log will cause the second log to be flushed.
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // index file should be there
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
+    EXPECT_EQ(STATUS_SUCCESS,
+              readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
+    fileIndexBuffer[fileIndexBufferSize] = '\0';
+    STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
+    EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
+
+    MEMFREE(logMessage);
 }
+
+TEST_F(FileLoggerFunctionalityTest, checkFileRotation)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2, i = 0, logIterationCount = 12, logFileCount = 0, maxLogFileCount = 5;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+    CHAR filePath[MAX_PATH_LEN];
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    for (; i < logIterationCount; ++i) {
+        SNPRINTF(filePath, MAX_PATH_LEN, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
+        FREMOVE(filePath);
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, maxLogFileCount,
+                                                     TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE));
+    logFunc = pClientCallbacks->logPrintFn;
+
+    // should create 12 files if limit allows
+    for (i = 0; i < logIterationCount; ++i) {
+        logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    for (i = 0; i < logIterationCount; ++i) {
+        SNPRINTF(filePath, MAX_PATH_LEN, TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".%u", i);
+        EXPECT_EQ(STATUS_SUCCESS, fileExists(filePath, &fileFound));
+        // only log file with index from 6 to 11 should remain. The rest are rotated out.
+        if (i < logIterationCount && i >= (logIterationCount - maxLogFileCount)) {
+            EXPECT_EQ(TRUE, fileFound);
+            logFileCount++;
+        } else {
+            EXPECT_EQ(FALSE, fileFound);
+        }
+    }
+
+    EXPECT_EQ(maxLogFileCount, logFileCount);
+
+    MEMFREE(logMessage);
 }
+
+TEST_F(FileLoggerFunctionalityTest, fileLoggerPicksUpFromLastFileIndex)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2, fileIndexStrSize = 256;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+    UINT64 currentFileIndex = 0;
+    CHAR fileIndexBuffer[256];
+    UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+
+    ULLTOSTR(128, fileIndexBuffer, ARRAY_SIZE(fileIndexBuffer), 10, &fileIndexStrSize);
+    EXPECT_EQ(STATUS_SUCCESS,
+              writeFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, FALSE, (PBYTE) fileIndexBuffer,
+                        STRLEN(fileIndexBuffer) * SIZEOF(CHAR)));
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR,
+                                                     FALSE));
+    logFunc = pClientCallbacks->logPrintFn;
+
+    // Cause a log flush.
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+
+    // check that log file name follows last index
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".128"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // index file should be there
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    // remaining log get flushed
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".129"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
+    EXPECT_EQ(STATUS_SUCCESS,
+              readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
+    fileIndexBuffer[fileIndexBufferSize] = '\0';
+    STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
+    EXPECT_EQ(130, currentFileIndex); // index should be incremented 3 times
+
+    MEMFREE(logMessage);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME ".128");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME ".129");
 }
+
+TEST_F(FileLoggerFunctionalityTest, logMessageLongerThanStringBuffer)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE + 100, i;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    PCHAR fileBuffer = (PCHAR) MEMALLOC(logMessageSize + 1);
+    UINT64 fileBufferLen = logMessageSize + 1;
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    // everthing starting from i should be truncated. So there should be no b in the log file.
+    // minus - 1 because vsnprintf prints at most MIN_FILE_LOGGER_STRING_BUFFER_SIZE - 1 chars.
+    for (i = MIN_FILE_LOGGER_STRING_BUFFER_SIZE - TIMESTRING_OFFSET - 1; i < logMessageSize; ++i) {
+        logMessage[i] = 'b';
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR,
+                                                     FALSE));
+    logFunc = pClientCallbacks->logPrintFn;
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    // no log should be produced as the only log message was dropped because it was too long.
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), TRUE, NULL, &fileBufferLen));
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), TRUE, (PBYTE) fileBuffer, &fileBufferLen));
+    fileBuffer[fileBufferLen] = '\0';
+
+    EXPECT_EQ('a', fileBuffer[STRLEN(fileBuffer) - 1]); // there should be no b in the log.
+
+    MEMFREE(logMessage);
+    MEMFREE(fileBuffer);
 }
+
+TEST_F(FileLoggerFunctionalityTest, oldLogFileOverrittenByFlushTriggerredByNewLog)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    PCHAR fileBuffer = (PCHAR) MEMALLOC(MIN_FILE_LOGGER_STRING_BUFFER_SIZE);
+    UINT64 fileBufferLen = MIN_FILE_LOGGER_STRING_BUFFER_SIZE;
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3");
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 3, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR,
+                                                     FALSE));
+    logFunc = pClientCallbacks->logPrintFn;
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    MEMSET(logMessage, 'b', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+
+    // kvsProducerLog.0 is deleted
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3"), TRUE, NULL, &fileBufferLen));
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".3"), TRUE, (PBYTE) fileBuffer, &fileBufferLen));
+    fileBuffer[fileBufferLen] = '\0';
+    // skip over the timestamp string
+    // use STRNCMP to not catch the newline at the end of fileBuffer
+    EXPECT_EQ(0, STRNCMP(logMessage, fileBuffer + TIMESTRING_OFFSET, STRLEN(logMessage)));
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    MEMFREE(logMessage);
+    MEMFREE(fileBuffer);
+}
+
+TEST_F(FileLoggerFunctionalityTest, oldLogFileOverrittenByFlushTriggerredByFreeCallbacks)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    PCHAR fileBuffer = (PCHAR) MEMALLOC(MIN_FILE_LOGGER_STRING_BUFFER_SIZE);
+    UINT64 fileBufferLen = MIN_FILE_LOGGER_STRING_BUFFER_SIZE;
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 1, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR,
+                                                     FALSE));
+    logFunc = pClientCallbacks->logPrintFn;
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+
+    MEMSET(logMessage, 'b', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), TRUE, NULL, &fileBufferLen));
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), TRUE, (PBYTE) fileBuffer, &fileBufferLen));
+    fileBuffer[fileBufferLen] = '\0';
+
+    // skip over the timestamp string
+    // use STRNCMP to not catch the newline at the end of fileBuffer
+    EXPECT_EQ(0, STRNCMP(logMessage, fileBuffer + TIMESTRING_OFFSET, STRLEN(logMessage)));
+
+    MEMFREE(logMessage);
+    MEMFREE(fileBuffer);
+}
+
+TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaCallbackNoGlobalLog)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+    UINT64 currentFileIndex = 0;
+    CHAR fileIndexBuffer[256];
+    UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+
+    EXPECT_EQ(STATUS_SUCCESS, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, FALSE, &logFunc));
+
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    // low log level logs have no effect
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should not have been flushed because we havent fill out string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound); // index file should not be there
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed because the new message overflows string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    // second log is still in buffer. Thus this log will cause the second log to be flushed.
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // index file should be there
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
+    EXPECT_EQ(STATUS_SUCCESS,
+              readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
+    fileIndexBuffer[fileIndexBufferSize] = '\0';
+    STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
+    EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
+
+    EXPECT_EQ(STATUS_SUCCESS, freeFileLogger());
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
+
+    MEMFREE(logMessage);
+}
+
+TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaCallbackWithGlobalLog)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+    UINT64 currentFileIndex = 0;
+    CHAR fileIndexBuffer[256];
+    UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+
+    EXPECT_EQ(STATUS_SUCCESS, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, TRUE, &logFunc));
+
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    // low log level logs have no effect
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should not have been flushed because we havent fill out string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound); // index file should not be there
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed because the new message overflows string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    // second log is still in buffer. Thus this log will cause the second log to be flushed.
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // index file should be there
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
+    EXPECT_EQ(STATUS_SUCCESS,
+              readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
+    fileIndexBuffer[fileIndexBufferSize] = '\0';
+    STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
+    EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
+
+    EXPECT_EQ(STATUS_SUCCESS, freeFileLogger());
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
+
+    MEMFREE(logMessage);
+}
+
+TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaGlobalLog)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    UINT64 currentFileIndex = 0;
+    CHAR fileIndexBuffer[256];
+    UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+
+    EXPECT_EQ(STATUS_SUCCESS, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5, TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, TRUE, NULL));
+
+    DLOGV("%s", logMessage);
+    DLOGV("%s", logMessage);
+    // low log level logs have no effect
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    DLOGE("%s", logMessage);
+    // log should not have been flushed because we havent fill out string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound); // index file should not be there
+
+    DLOGE("%s", logMessage);
+    // log should have been flushed because the new message overflows string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    // second log is still in buffer. Thus this log will cause the second log to be flushed.
+    DLOGE("%s", logMessage);
+    // log should have been flushed
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // index file should be there
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
+    EXPECT_EQ(STATUS_SUCCESS,
+              readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
+    fileIndexBuffer[fileIndexBufferSize] = '\0';
+    STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
+    EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
+
+    EXPECT_EQ(STATUS_SUCCESS, freeFileLogger());
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
+
+    MEMFREE(logMessage);
+}
+
+TEST_F(FileLoggerFunctionalityTest, basicCommonFileLoggerUsageViaGlobalLogSetResetMacros)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    UINT64 currentFileIndex = 0;
+    CHAR fileIndexBuffer[256];
+    UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+
+    // make sure the files dont exist
+    FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+
+    EXPECT_EQ(STATUS_SUCCESS, SET_FILE_LOGGER());
+
+    DLOGE("%s", logMessage);
+    // log should not have been flushed because we havent fill out string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound); // index file should not be there
+
+    EXPECT_EQ(STATUS_SUCCESS, RESET_FILE_LOGGER());
+
+    // log should not have been flushed because we havent fill out string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // remaining log get flushed when callbacks are freed.
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (FILE_LOGGER_LOG_FILE_DIRECTORY_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    MEMFREE(logMessage);
+
+    // Ensure we can still log err
+    DLOGE("Printout after reset");
+}
+
+TEST_F(FileLoggerFunctionalityTest, basicFilterFileLoggerUsage)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    UINT32 logMessageSize = MIN_FILE_LOGGER_STRING_BUFFER_SIZE / 2;
+    PCHAR logMessage = (PCHAR) MEMALLOC(logMessageSize + 1);
+    BOOL fileFound = FALSE;
+    LogPrintFunc logFunc;
+    UINT64 currentFileIndex = 0;
+    CHAR fileIndexBuffer[256];
+    UINT64 fileIndexBufferSize = ARRAY_SIZE(fileIndexBuffer);
+
+    MEMSET(logMessage, 'a', logMessageSize);
+    logMessage[logMessageSize] = '\0';
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
+
+    // make sure the files dont exist
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2");
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              addFileLoggerWithFilteringPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 5,
+                                                                  TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR, FALSE, TRUE, LOG_LEVEL_WARN));
+    logFunc = pClientCallbacks->logPrintFn;
+
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    logFunc(LOG_LEVEL_VERBOSE, NULL, (PCHAR) "%s", logMessage);
+    // low log level logs have no effect
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should not have been flushed because we havent fill out string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound); // index file should not be there
+
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed because the new message overflows string buffer
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // index file should not be there
+
+    // second log is still in buffer. Thus this log will cause the second log to be flushed.
+    logFunc(LOG_LEVEL_ERROR, NULL, (PCHAR) "%s", logMessage);
+    // log should have been flushed
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound); // index file should be there
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
+    EXPECT_EQ(STATUS_SUCCESS,
+              readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
+    fileIndexBuffer[fileIndexBufferSize] = '\0';
+    STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
+    EXPECT_EQ(2, currentFileIndex); // index should be 2 since we flushed twice.
+
+    logFunc(LOG_LEVEL_WARN, NULL, (PCHAR) "%s", logMessage);
+
+    // We would still not see the log file flushed because the file is not filled
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(FALSE, fileFound);
+
+    logFunc(LOG_LEVEL_WARN, NULL, (PCHAR) "%s", logMessage);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    logFunc(LOG_LEVEL_WARN, NULL, (PCHAR) "%s", logMessage);
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    // Expect new log filter file to be created despite log file not being filled because we release the file logger
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".1"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    // remaining log get flushed when callbacks are freed.
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".2"), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, fileExists((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), &fileFound));
+    EXPECT_EQ(TRUE, fileFound);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), TRUE, NULL, &fileIndexBufferSize));
+    EXPECT_EQ(STATUS_SUCCESS,
+              readFile((PCHAR) (TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME), TRUE, (PBYTE) fileIndexBuffer, &fileIndexBufferSize));
+    fileIndexBuffer[fileIndexBufferSize] = '\0';
+    STRTOUI64(fileIndexBuffer, NULL, 10, &currentFileIndex);
+    EXPECT_EQ(3, currentFileIndex); // index should be 3 since we flushed twice.
+
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LAST_FILTER_INDEX_FILE_NAME);
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".0");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".1");
+    FREMOVE(TEST_TEMP_DIR_PATH FILE_LOGGER_FILTER_LOG_FILE_NAME ".2");
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+    MEMFREE(logMessage);
+}
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/InfoProviderApiTest.cpp
+++ b/tst/InfoProviderApiTest.cpp
@@ -1,326 +1,232 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
-
-    class InfoProviderApiTest : public ProducerClientTestBase {
-    };
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-    TEST_F(InfoProviderApiTest, CreateDefaultDeviceInfo_Returns_Success)
-    {
-        PDeviceInfo pDeviceInfo;
+class InfoProviderApiTest : public ProducerClientTestBase {};
 
-        EXPECT_EQ(STATUS_SUCCESS, createDefaultDeviceInfo(&pDeviceInfo));
+TEST_F(InfoProviderApiTest, CreateDefaultDeviceInfo_Returns_Success)
+{
+    PDeviceInfo pDeviceInfo;
 
-        EXPECT_EQ(STATUS_SUCCESS, setDeviceInfoStorageSize(pDeviceInfo, MAX_STORAGE_ALLOCATION_SIZE));
+    EXPECT_EQ(STATUS_SUCCESS, createDefaultDeviceInfo(&pDeviceInfo));
 
-        EXPECT_EQ(STATUS_INVALID_STORAGE_SIZE, setDeviceInfoStorageSize(pDeviceInfo, MAX_STORAGE_ALLOCATION_SIZE + 1));
+    EXPECT_EQ(STATUS_SUCCESS, setDeviceInfoStorageSize(pDeviceInfo, MAX_STORAGE_ALLOCATION_SIZE));
 
-        EXPECT_TRUE(pDeviceInfo->clientInfo.loggerLogLevel == this->loggerLogLevel);
+    EXPECT_EQ(STATUS_INVALID_STORAGE_SIZE, setDeviceInfoStorageSize(pDeviceInfo, MAX_STORAGE_ALLOCATION_SIZE + 1));
 
-        // 500 Kbps with 2 sec duration
-        EXPECT_EQ(STATUS_SUCCESS,
-                  setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo,
-                                                                          500 * 1000 * 8,
-                                                                          2 * HUNDREDS_OF_NANOS_IN_A_SECOND));
-        // 500 Kbps with 10 sec duration
-        EXPECT_EQ(STATUS_SUCCESS,
-                  setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo,
-                                                                          500 * 1000 * 8,
-                                                                          10 * HUNDREDS_OF_NANOS_IN_A_SECOND));
-        // 1000 Kbps with 10 sec duration
-        EXPECT_EQ(STATUS_SUCCESS,
-                  setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo,
-                                                                          1000 * 1000 * 8,
-                                                                          10 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+    EXPECT_TRUE(pDeviceInfo->clientInfo.loggerLogLevel == this->loggerLogLevel);
 
-        EXPECT_EQ(STATUS_INVALID_ARG,
-                  setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo,
-                                                                          0,
-                                                                          0 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+    // 500 Kbps with 2 sec duration
+    EXPECT_EQ(STATUS_SUCCESS,
+              setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo, 500 * 1000 * 8, 2 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+    // 500 Kbps with 10 sec duration
+    EXPECT_EQ(STATUS_SUCCESS,
+              setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo, 500 * 1000 * 8, 10 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+    // 1000 Kbps with 10 sec duration
+    EXPECT_EQ(STATUS_SUCCESS,
+              setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo, 1000 * 1000 * 8, 10 * HUNDREDS_OF_NANOS_IN_A_SECOND));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(NULL,
-                                                                          0,
-                                                                          0 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+    EXPECT_EQ(STATUS_INVALID_ARG, setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(pDeviceInfo, 0, 0 * HUNDREDS_OF_NANOS_IN_A_SECOND));
 
-        EXPECT_EQ(STATUS_NULL_ARG, createDefaultDeviceInfo(NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, setDeviceInfoStorageSizeBasedOnBitrateAndBufferDuration(NULL, 0, 0 * HUNDREDS_OF_NANOS_IN_A_SECOND));
 
-        EXPECT_EQ(STATUS_NULL_ARG, setDeviceInfoStorageSize(NULL, MAX_STORAGE_ALLOCATION_SIZE));
+    EXPECT_EQ(STATUS_NULL_ARG, createDefaultDeviceInfo(NULL));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeDeviceInfo(&pDeviceInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, setDeviceInfoStorageSize(NULL, MAX_STORAGE_ALLOCATION_SIZE));
 
-        EXPECT_EQ(NULL, pDeviceInfo);
+    EXPECT_EQ(STATUS_SUCCESS, freeDeviceInfo(&pDeviceInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeDeviceInfo(&pDeviceInfo));
+    EXPECT_EQ(NULL, pDeviceInfo);
 
-        EXPECT_EQ(STATUS_NULL_ARG, freeDeviceInfo(NULL));
+    EXPECT_EQ(STATUS_SUCCESS, freeDeviceInfo(&pDeviceInfo));
 
-    }
+    EXPECT_EQ(STATUS_NULL_ARG, freeDeviceInfo(NULL));
+}
 
-    TEST_F(InfoProviderApiTest, CreateOfflineVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
-    {
-        PStreamInfo pStreamInfo;
+TEST_F(InfoProviderApiTest, CreateOfflineVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
+{
+    PStreamInfo pStreamInfo;
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                       TEST_RETENTION_PERIOD,
-                                                       TEST_STREAM_BUFFER_DURATION,
-                                                       &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(FRAME_ORDER_MODE_PASS_THROUGH, pStreamInfo->streamCaps.frameOrderingMode);
-        EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList->trackType);
-        EXPECT_EQ(STREAMING_TYPE_OFFLINE, pStreamInfo->streamCaps.streamingType);
-        EXPECT_NE(0, pStreamInfo->retention);
-        EXPECT_EQ(1, pStreamInfo->streamCaps.trackInfoCount);
-        EXPECT_EQ(TRUE, pStreamInfo->streamCaps.absoluteFragmentTimes);
+    EXPECT_EQ(FRAME_ORDER_MODE_PASS_THROUGH, pStreamInfo->streamCaps.frameOrderingMode);
+    EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList->trackType);
+    EXPECT_EQ(STREAMING_TYPE_OFFLINE, pStreamInfo->streamCaps.streamingType);
+    EXPECT_NE(0, pStreamInfo->retention);
+    EXPECT_EQ(1, pStreamInfo->streamCaps.trackInfoCount);
+    EXPECT_EQ(TRUE, pStreamInfo->streamCaps.absoluteFragmentTimes);
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createOfflineVideoStreamInfoProvider(NULL,
-                                                       TEST_RETENTION_PERIOD,
-                                                       TEST_STREAM_BUFFER_DURATION,
-                                                       &pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, createOfflineVideoStreamInfoProvider(NULL, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createOfflineVideoStreamInfoProvider(EMPTY_STRING,
-                                                       TEST_RETENTION_PERIOD,
-                                                       TEST_STREAM_BUFFER_DURATION,
-                                                       &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, createOfflineVideoStreamInfoProvider(EMPTY_STRING, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_INVALID_ARG,
-                  createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                       0,
-                                                       TEST_STREAM_BUFFER_DURATION,
-                                                       &pStreamInfo));
+    EXPECT_EQ(STATUS_INVALID_ARG, createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME, 0, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_INVALID_ARG,
-                  createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                       TEST_RETENTION_PERIOD,
-                                                       0,
-                                                       &pStreamInfo));
+    EXPECT_EQ(STATUS_INVALID_ARG, createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, 0, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                       TEST_RETENTION_PERIOD,
-                                                       TEST_STREAM_BUFFER_DURATION,
-                                                       NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, createOfflineVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, NULL));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(NULL, pStreamInfo);
+    EXPECT_EQ(NULL, pStreamInfo);
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+}
 
-    }
+TEST_F(InfoProviderApiTest, CreateRealTimeVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
+{
+    PStreamInfo pStreamInfo;
 
-    TEST_F(InfoProviderApiTest, CreateRealTimeVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
-    {
-        PStreamInfo pStreamInfo;
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                        TEST_RETENTION_PERIOD,
-                                                        TEST_STREAM_BUFFER_DURATION,
-                                                        &pStreamInfo));
+    EXPECT_EQ(FRAME_ORDER_MODE_PASS_THROUGH, pStreamInfo->streamCaps.frameOrderingMode);
+    EXPECT_EQ(1, pStreamInfo->streamCaps.trackInfoCount);
+    EXPECT_EQ(STREAMING_TYPE_REALTIME, pStreamInfo->streamCaps.streamingType);
+    EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList[0].trackType);
 
-        EXPECT_EQ(FRAME_ORDER_MODE_PASS_THROUGH, pStreamInfo->streamCaps.frameOrderingMode);
-        EXPECT_EQ(1, pStreamInfo->streamCaps.trackInfoCount);
-        EXPECT_EQ(STREAMING_TYPE_REALTIME, pStreamInfo->streamCaps.streamingType);
-        EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList[0].trackType);
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, createRealtimeVideoStreamInfoProvider(NULL, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createRealtimeVideoStreamInfoProvider(NULL,
-                                                        TEST_RETENTION_PERIOD,
-                                                        TEST_STREAM_BUFFER_DURATION,
-                                                        &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(EMPTY_STRING, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createRealtimeVideoStreamInfoProvider(EMPTY_STRING,
-                                                        TEST_RETENTION_PERIOD,
-                                                        TEST_STREAM_BUFFER_DURATION,
-                                                        &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME, 0, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                        0,
-                                                        TEST_STREAM_BUFFER_DURATION,
-                                                        &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, NULL));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                        TEST_RETENTION_PERIOD,
-                                                        TEST_STREAM_BUFFER_DURATION,
-                                                        NULL));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(NULL, pStreamInfo);
 
-        EXPECT_EQ(NULL, pStreamInfo);
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+}
 
-        EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+TEST_F(InfoProviderApiTest, CreateRealTimeAudioVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
+{
+    PStreamInfo pStreamInfo;
 
-    }
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-    TEST_F(InfoProviderApiTest, CreateRealTimeAudioVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
-    {
-        PStreamInfo pStreamInfo;
+    EXPECT_EQ(FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_PTS_ONE_MS_COMPENSATE_EOFR, pStreamInfo->streamCaps.frameOrderingMode);
+    EXPECT_EQ(2, pStreamInfo->streamCaps.trackInfoCount);
+    EXPECT_EQ(STREAMING_TYPE_REALTIME, pStreamInfo->streamCaps.streamingType);
+    EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList[0].trackType);
+    EXPECT_EQ(MKV_TRACK_INFO_TYPE_AUDIO, pStreamInfo->streamCaps.trackInfoList[1].trackType);
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                             TEST_RETENTION_PERIOD,
-                                                             TEST_STREAM_BUFFER_DURATION,
-                                                             &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
 
-        EXPECT_EQ(FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_PTS_ONE_MS_COMPENSATE_EOFR, pStreamInfo->streamCaps.frameOrderingMode);
-        EXPECT_EQ(2, pStreamInfo->streamCaps.trackInfoCount);
-        EXPECT_EQ(STREAMING_TYPE_REALTIME, pStreamInfo->streamCaps.streamingType);
-        EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList[0].trackType);
-        EXPECT_EQ(MKV_TRACK_INFO_TYPE_AUDIO, pStreamInfo->streamCaps.trackInfoList[1].trackType);
+    EXPECT_EQ(STATUS_NULL_ARG, createRealtimeAudioVideoStreamInfoProvider(NULL, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
-        EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRealtimeAudioVideoStreamInfoProvider(EMPTY_STRING, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createRealtimeAudioVideoStreamInfoProvider(NULL,
-                                                             TEST_RETENTION_PERIOD,
-                                                             TEST_STREAM_BUFFER_DURATION,
-                                                             &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createRealtimeAudioVideoStreamInfoProvider(EMPTY_STRING,
-                                                             TEST_RETENTION_PERIOD,
-                                                             TEST_STREAM_BUFFER_DURATION,
-                                                             &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME, 0, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                             0,
-                                                             TEST_STREAM_BUFFER_DURATION,
-                                                             &pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, NULL));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                             TEST_RETENTION_PERIOD,
-                                                             TEST_STREAM_BUFFER_DURATION,
-                                                             NULL));
+    EXPECT_EQ(NULL, pStreamInfo);
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(NULL, pStreamInfo);
+    EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+}
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+TEST_F(InfoProviderApiTest, setStreamInfoBasedOnStorageSizeApiTest)
+{
+    PStreamInfo pStreamInfo;
 
-        EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-    }
+    EXPECT_EQ(STATUS_INVALID_ARG, setStreamInfoBasedOnStorageSize(0, 1000000, 1, pStreamInfo));
+    EXPECT_EQ(STATUS_INVALID_ARG, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 0, 1, pStreamInfo));
+    EXPECT_EQ(STATUS_INVALID_ARG, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 1000000, 0, pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 1000000, 1, NULL));
 
-    TEST_F(InfoProviderApiTest, setStreamInfoBasedOnStorageSizeApiTest) {
-        PStreamInfo pStreamInfo;
+    EXPECT_EQ(STATUS_SUCCESS, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 1000000, 1, pStreamInfo));
+    EXPECT_TRUE(pStreamInfo->streamCaps.bufferDuration != TEST_STREAM_BUFFER_DURATION);
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createRealtimeVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                        TEST_RETENTION_PERIOD,
-                                                        TEST_STREAM_BUFFER_DURATION,
-                                                        &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+}
 
-        EXPECT_EQ(STATUS_INVALID_ARG, setStreamInfoBasedOnStorageSize(0, 1000000, 1, pStreamInfo));
-        EXPECT_EQ(STATUS_INVALID_ARG, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 0, 1, pStreamInfo));
-        EXPECT_EQ(STATUS_INVALID_ARG, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 1000000, 0, pStreamInfo));
-        EXPECT_EQ(STATUS_NULL_ARG, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 1000000, 1, NULL));
+TEST_F(InfoProviderApiTest, CreateOfflineAudioVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
+{
+    PStreamInfo pStreamInfo;
 
-        EXPECT_EQ(STATUS_SUCCESS, setStreamInfoBasedOnStorageSize(2 * 1024 * 1024, 1000000, 1, pStreamInfo));
-        EXPECT_TRUE(pStreamInfo->streamCaps.bufferDuration != TEST_STREAM_BUFFER_DURATION);
+    EXPECT_EQ(STATUS_SUCCESS,
+              createOfflineAudioVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
-    }
+    EXPECT_EQ(FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_PTS_ONE_MS_COMPENSATE_EOFR, pStreamInfo->streamCaps.frameOrderingMode);
+    EXPECT_EQ(2, pStreamInfo->streamCaps.trackInfoCount);
+    EXPECT_EQ(STREAMING_TYPE_OFFLINE, pStreamInfo->streamCaps.streamingType);
+    EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList[0].trackType);
+    EXPECT_EQ(MKV_TRACK_INFO_TYPE_AUDIO, pStreamInfo->streamCaps.trackInfoList[1].trackType);
 
-    TEST_F(InfoProviderApiTest, CreateOfflineAudioVideoStreamInfoProvider_Returns_ValidVideoStreamInfo)
-    {
-        PStreamInfo pStreamInfo;
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createOfflineAudioVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                            TEST_RETENTION_PERIOD,
-                                                            TEST_STREAM_BUFFER_DURATION,
-                                                            &pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, createOfflineAudioVideoStreamInfoProvider(NULL, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_PTS_ONE_MS_COMPENSATE_EOFR, pStreamInfo->streamCaps.frameOrderingMode);
-        EXPECT_EQ(2, pStreamInfo->streamCaps.trackInfoCount);
-        EXPECT_EQ(STREAMING_TYPE_OFFLINE, pStreamInfo->streamCaps.streamingType);
-        EXPECT_EQ(MKV_TRACK_INFO_TYPE_VIDEO, pStreamInfo->streamCaps.trackInfoList[0].trackType);
-        EXPECT_EQ(MKV_TRACK_INFO_TYPE_AUDIO, pStreamInfo->streamCaps.trackInfoList[1].trackType);
+    EXPECT_EQ(STATUS_SUCCESS,
+              createOfflineAudioVideoStreamInfoProvider(EMPTY_STRING, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createOfflineAudioVideoStreamInfoProvider(NULL,
-                                                            TEST_RETENTION_PERIOD,
-                                                            TEST_STREAM_BUFFER_DURATION,
-                                                            &pStreamInfo));
+    EXPECT_EQ(STATUS_INVALID_ARG, createOfflineAudioVideoStreamInfoProvider(TEST_STREAM_NAME, 0, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  createOfflineAudioVideoStreamInfoProvider(EMPTY_STRING,
-                                                            TEST_RETENTION_PERIOD,
-                                                            TEST_STREAM_BUFFER_DURATION,
-                                                            &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, createOfflineAudioVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, NULL));
 
-        EXPECT_EQ(STATUS_INVALID_ARG,
-                  createOfflineAudioVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                            0,
-                                                            TEST_STREAM_BUFFER_DURATION,
-                                                            &pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(NULL, pStreamInfo);
 
-        EXPECT_EQ(STATUS_NULL_ARG,
-                  createOfflineAudioVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                            TEST_RETENTION_PERIOD,
-                                                            TEST_STREAM_BUFFER_DURATION,
-                                                            NULL));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
+}
 
-        EXPECT_EQ(NULL, pStreamInfo);
+TEST_F(InfoProviderApiTest, CreateStream_Returns_Success)
+{
+    PStreamCallbacks pStreamCallbacks;
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamInfoProvider(&pStreamInfo));
+    EXPECT_EQ(STATUS_SUCCESS, createStreamCallbacks(&pStreamCallbacks));
 
-        EXPECT_EQ(STATUS_NULL_ARG, freeStreamInfoProvider(NULL));
-    }
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamCallbacks(&pStreamCallbacks));
 
-    TEST_F(InfoProviderApiTest, CreateStream_Returns_Success)
-    {
-        PStreamCallbacks pStreamCallbacks;
+    EXPECT_EQ(NULL, pStreamCallbacks);
 
-        EXPECT_EQ(STATUS_SUCCESS, createStreamCallbacks(&pStreamCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS, freeStreamCallbacks(&pStreamCallbacks));
 
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamCallbacks(&pStreamCallbacks));
-
-        EXPECT_EQ(NULL, pStreamCallbacks);
-
-        EXPECT_EQ(STATUS_SUCCESS, freeStreamCallbacks(&pStreamCallbacks));
-
-        EXPECT_EQ(STATUS_NULL_ARG, createStreamCallbacks(NULL));
-    }
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
-
+    EXPECT_EQ(STATUS_NULL_ARG, createStreamCallbacks(NULL));
+}
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/PlatformCallbackProviderApiTest.cpp
+++ b/tst/PlatformCallbackProviderApiTest.cpp
@@ -1,84 +1,57 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-    class PlatformCallbackProviderApiTest : public ProducerClientTestBase {
-    };
+class PlatformCallbackProviderApiTest : public ProducerClientTestBase {};
 
-    TEST_F(PlatformCallbackProviderApiTest, SetPlatformCallbackProvider_Returns_Valid)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
+TEST_F(PlatformCallbackProviderApiTest, SetPlatformCallbackProvider_Returns_Valid)
+{
+    PClientCallbacks pClientCallbacks = NULL;
 
-        EXPECT_EQ(STATUS_NULL_ARG, setDefaultPlatformCallbacks((PCallbacksProvider) pClientCallbacks));
+    EXPECT_EQ(STATUS_NULL_ARG, setDefaultPlatformCallbacks((PCallbacksProvider) pClientCallbacks));
 
-        PlatformCallbacks platformCallbacks = {
-                PLATFORM_CALLBACKS_CURRENT_VERSION,
-                0,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL
-        };
+    PlatformCallbacks platformCallbacks = {
+        PLATFORM_CALLBACKS_CURRENT_VERSION, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
-        EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                 TEST_ACCESS_KEY,
-                                                                 TEST_SECRET_KEY,
-                                                                 TEST_SESSION_TOKEN,
-                                                                 TEST_STREAMING_TOKEN_DURATION,
-                                                                 TEST_DEFAULT_REGION,
-                                                                 TEST_CONTROL_PLANE_URI,
-                                                                 mCaCertPath,
-                                                                 NULL,
-                                                                 TEST_USER_AGENT,
-                                                                 API_CALL_CACHE_TYPE_NONE,
-                                                                 TEST_CACHING_ENDPOINT_PERIOD,
-                                                                 TRUE,
-                                                                 &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
 
-        setPlatformCallbacks(pClientCallbacks, &platformCallbacks);
+    setPlatformCallbacks(pClientCallbacks, &platformCallbacks);
 
-        EXPECT_TRUE(broadcastConditionVariableAggregate != pClientCallbacks->broadcastConditionVariableFn);
+    EXPECT_TRUE(broadcastConditionVariableAggregate != pClientCallbacks->broadcastConditionVariableFn);
 
-        EXPECT_TRUE(createMutexAggregate != pClientCallbacks->createMutexFn);
-        EXPECT_TRUE(createConditionVariableAggregate != pClientCallbacks->createConditionVariableFn);
-        EXPECT_TRUE(freeMutexAggregate != pClientCallbacks->freeMutexFn);
-        EXPECT_TRUE(freeConditionVariableAggregate != pClientCallbacks->freeConditionVariableFn);
-        EXPECT_TRUE(getCurrentTimeAggregate != pClientCallbacks->getCurrentTimeFn);
-        EXPECT_TRUE(getRandomNumberAggregate != pClientCallbacks->getRandomNumberFn);
-        EXPECT_TRUE(lockMutexAggregate != pClientCallbacks->lockMutexFn);
-        EXPECT_TRUE(signalConditionVariableAggregate != pClientCallbacks->signalConditionVariableFn);
-        EXPECT_TRUE(unlockMutexAggregate != pClientCallbacks->unlockMutexFn);
-        EXPECT_TRUE(unlockMutexAggregate != pClientCallbacks->unlockMutexFn);
-        EXPECT_TRUE(waitConditionVariableAggregate != pClientCallbacks->waitConditionVariableFn);
+    EXPECT_TRUE(createMutexAggregate != pClientCallbacks->createMutexFn);
+    EXPECT_TRUE(createConditionVariableAggregate != pClientCallbacks->createConditionVariableFn);
+    EXPECT_TRUE(freeMutexAggregate != pClientCallbacks->freeMutexFn);
+    EXPECT_TRUE(freeConditionVariableAggregate != pClientCallbacks->freeConditionVariableFn);
+    EXPECT_TRUE(getCurrentTimeAggregate != pClientCallbacks->getCurrentTimeFn);
+    EXPECT_TRUE(getRandomNumberAggregate != pClientCallbacks->getRandomNumberFn);
+    EXPECT_TRUE(lockMutexAggregate != pClientCallbacks->lockMutexFn);
+    EXPECT_TRUE(signalConditionVariableAggregate != pClientCallbacks->signalConditionVariableFn);
+    EXPECT_TRUE(unlockMutexAggregate != pClientCallbacks->unlockMutexFn);
+    EXPECT_TRUE(unlockMutexAggregate != pClientCallbacks->unlockMutexFn);
+    EXPECT_TRUE(waitConditionVariableAggregate != pClientCallbacks->waitConditionVariableFn);
 
-        //non-null callback definition should return aggregated platform callback
-        platformCallbacks.getCurrentTimeFn = (UINT64 (*)(UINT64)) 2;
+    // non-null callback definition should return aggregated platform callback
+    platformCallbacks.getCurrentTimeFn = (UINT64(*)(UINT64)) 2;
 
-        setPlatformCallbacks(pClientCallbacks, &platformCallbacks);
+    setPlatformCallbacks(pClientCallbacks, &platformCallbacks);
 
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-        EXPECT_EQ(NULL, pClientCallbacks);
+    EXPECT_EQ(NULL, pClientCallbacks);
 
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
-        EXPECT_EQ(STATUS_NULL_ARG, freeCallbacksProvider(NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, freeCallbacksProvider(NULL));
+}
 
-    }
-
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
-
-
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerApiCallCacheTest.cpp
+++ b/tst/ProducerApiCallCacheTest.cpp
@@ -1,9 +1,11 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class ProducerApiCallCacheTest : public ProducerClientTestBase {
-};
+class ProducerApiCallCacheTest : public ProducerClientTestBase {};
 
 TEST_F(ProducerApiCallCacheTest, basicValidateNoCaching)
 {
@@ -143,7 +145,7 @@ TEST_F(ProducerApiCallCacheTest, basicValidateCachingAllApis)
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-}
-}
-}
-}
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerApiTest.cpp
+++ b/tst/ProducerApiTest.cpp
@@ -1,9 +1,11 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class ProducerApiTest : public ProducerClientTestBase {
-};
+class ProducerApiTest : public ProducerClientTestBase {};
 
 TEST_F(ProducerApiTest, fileLoggerCallbackApiTest)
 {
@@ -13,22 +15,22 @@ TEST_F(ProducerApiTest, fileLoggerCallbackApiTest)
 
     MEMSET(longPath, 0x01, MAX_PATH_LEN + 2);
     longPath[MAX_PATH_LEN + 1] = '\0';
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     API_CALL_CACHE_TYPE_NONE,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     TEST_DEFAULT_REGION,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     EMPTY_STRING,
-                                                                     NULL,
-                                                                     TEST_USER_AGENT,
-                                                                     &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                                     TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, EMPTY_STRING, NULL, TEST_USER_AGENT,
+                                                     &pClientCallbacks));
 
     EXPECT_EQ(STATUS_NULL_ARG, addFileLoggerPlatformCallbacksProvider(NULL, 10 * 1024, 10, testLogDir, FALSE));
-    EXPECT_EQ(STATUS_INVALID_ARG, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE - 1, 10, testLogDir, FALSE));
-    EXPECT_EQ(STATUS_INVALID_ARG, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MAX_FILE_LOGGER_STRING_BUFFER_SIZE + 1, 10, testLogDir, FALSE));
-    EXPECT_EQ(STATUS_INVALID_ARG, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, MAX_FILE_LOGGER_LOG_FILE_COUNT + 1, testLogDir, FALSE));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE - 1, 10, testLogDir, FALSE));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MAX_FILE_LOGGER_STRING_BUFFER_SIZE + 1, 10, testLogDir, FALSE));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, MAX_FILE_LOGGER_LOG_FILE_COUNT + 1,
+                                                     testLogDir, FALSE));
     EXPECT_EQ(STATUS_INVALID_ARG, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 0, testLogDir, FALSE));
-    EXPECT_EQ(STATUS_PATH_TOO_LONG, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 10, longPath, FALSE));
+    EXPECT_EQ(STATUS_PATH_TOO_LONG,
+              addFileLoggerPlatformCallbacksProvider(pClientCallbacks, MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 10, longPath, FALSE));
 
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks)); // idempotent
@@ -44,12 +46,13 @@ TEST_F(ProducerApiTest, fileLoggerApiTest)
 
     EXPECT_EQ(STATUS_INVALID_ARG, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE - 1, 10, testLogDir, FALSE, FALSE, NULL));
     EXPECT_EQ(STATUS_INVALID_ARG, createFileLogger(MAX_FILE_LOGGER_STRING_BUFFER_SIZE + 1, 10, testLogDir, FALSE, FALSE, NULL));
-    EXPECT_EQ(STATUS_INVALID_ARG, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, MAX_FILE_LOGGER_LOG_FILE_COUNT + 1, testLogDir, FALSE, FALSE, NULL));
+    EXPECT_EQ(STATUS_INVALID_ARG,
+              createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, MAX_FILE_LOGGER_LOG_FILE_COUNT + 1, testLogDir, FALSE, FALSE, NULL));
     EXPECT_EQ(STATUS_INVALID_ARG, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 0, testLogDir, FALSE, FALSE, NULL));
     EXPECT_EQ(STATUS_PATH_TOO_LONG, createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE, 10, longPath, FALSE, FALSE, NULL));
 }
 
-}
-}
-}
-}
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerBasicUsageTest.cpp
+++ b/tst/ProducerBasicUsageTest.cpp
@@ -1,9 +1,11 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class ProducerBasicUsageTest : public ProducerClientTestBase {
-};
+class ProducerBasicUsageTest : public ProducerClientTestBase {};
 
 TEST_F(ProducerBasicUsageTest, videoOnlyUsage)
 {
@@ -57,7 +59,7 @@ CleanUp:
     EXPECT_EQ(STATUS_SUCCESS, retStatus);
 }
 
-}
-}
-}
-}
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerCallbackProviderApiTest.cpp
+++ b/tst/ProducerCallbackProviderApiTest.cpp
@@ -1,115 +1,95 @@
 #include "ProducerTestFixture.h"
 #include <map>
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-    class ProducerCallbackProviderApiTest : public ProducerClientTestBase {
+class ProducerCallbackProviderApiTest : public ProducerClientTestBase {};
+
+TEST_F(ProducerCallbackProviderApiTest, AddProducerCallbackProvider_Returns_Valid)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+
+    ProducerCallbacks producerCallbacks = {PRODUCER_CALLBACKS_CURRENT_VERSION, 0, NULL, NULL, NULL, NULL};
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                             TEST_STREAMING_TOKEN_DURATION, TEST_DEFAULT_REGION, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
+
+    addProducerCallbacks(pClientCallbacks, &producerCallbacks);
+
+    EXPECT_TRUE(clientReadyAggregate != pClientCallbacks->clientReadyFn);
+    EXPECT_TRUE(clientShutdownAggregate != producerCallbacks.clientShutdownFn);
+    EXPECT_TRUE(storageOverflowPressureAggregate != producerCallbacks.storageOverflowPressureFn);
+
+    // non-null callback definition should return aggregated platform callback
+    producerCallbacks.clientReadyFn = (UINT32(*)(UINT64, UINT64)) 2;
+
+    addProducerCallbacks(pClientCallbacks, &producerCallbacks);
+
+    addProducerCallbacks(pClientCallbacks, &producerCallbacks);
+    EXPECT_TRUE(4 == ((PCallbacksProvider) pClientCallbacks)->producerCallbacksCount);
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    EXPECT_EQ(NULL, pClientCallbacks);
+
+    EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
+
+    EXPECT_EQ(STATUS_NULL_ARG, freeCallbacksProvider(NULL));
+}
+
+TEST_F(ProducerCallbackProviderApiTest, TestCorrectControlPlaneUriForSpecifiedRegion)
+{
+    PClientCallbacks pClientCallbacks = NULL;
+    // Map region to control plane url
+    std::map<std::string, std::string> regionToControlPlaneUrlMap = {
+        {"us-east-1", "https://kinesisvideo.us-east-1.amazonaws.com"},
+        {"us-west-2", "https://kinesisvideo.us-west-2.amazonaws.com"},
+        {"ap-northeast-1", "https://kinesisvideo.ap-northeast-1.amazonaws.com"},
+        {"ap-southeast-2", "https://kinesisvideo.ap-southeast-2.amazonaws.com"},
+        {"eu-central-1", "https://kinesisvideo.eu-central-1.amazonaws.com"},
+        {"eu-west-1", "https://kinesisvideo.eu-west-1.amazonaws.com"},
+        {"ap-northeast-2", "https://kinesisvideo.ap-northeast-2.amazonaws.com"},
+        {"ap-south-1", "https://kinesisvideo.ap-south-1.amazonaws.com"},
+        {"ap-southeast-1", "https://kinesisvideo.ap-southeast-1.amazonaws.com"},
+        {"ca-central-1", "https://kinesisvideo.ca-central-1.amazonaws.com"},
+        {"eu-north-1", "https://kinesisvideo.eu-north-1.amazonaws.com"},
+        {"eu-west-2", "https://kinesisvideo.eu-west-2.amazonaws.com"},
+        {"sa-east-1", "https://kinesisvideo.sa-east-1.amazonaws.com"},
+        {"us-east-2", "https://kinesisvideo.us-east-2.amazonaws.com"},
+        {"ap-east-1", "https://kinesisvideo.ap-east-1.amazonaws.com"},
+        {"af-south-1", "https://kinesisvideo.af-south-1.amazonaws.com"},
+        {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.c2s.ic.gov"},
+        {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.c2s.ic.gov"},
+        {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.sc2s.sgov.gov"},
+        {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.amazonaws.com"},
+        {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.amazonaws.com"},
+        {"cn-north-1", "https://kinesisvideo.cn-north-1.amazonaws.com.cn"},
+        {"cn-northwest-1", "https://kinesisvideo.cn-northwest-1.amazonaws.com.cn"},
     };
 
-    TEST_F(ProducerCallbackProviderApiTest, AddProducerCallbackProvider_Returns_Valid)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
+    for (auto it : regionToControlPlaneUrlMap) {
+        EXPECT_EQ(STATUS_SUCCESS,
+                  createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
+                                                 TEST_STREAMING_TOKEN_DURATION, (PCHAR) it.first.c_str(), TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                                 TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
 
-        ProducerCallbacks producerCallbacks = {
-                PRODUCER_CALLBACKS_CURRENT_VERSION,
-                0,
-                NULL,
-                NULL,
-                NULL,
-                NULL
-        };
+        PCallbacksProvider pCallbacksProvider = (PCallbacksProvider) pClientCallbacks;
+        PCurlApiCallbacks pCurlApiCallbacks = (PCurlApiCallbacks) pCallbacksProvider->pApiCallbacks[0].customData;
 
-        EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                 TEST_ACCESS_KEY,
-                                                                 TEST_SECRET_KEY,
-                                                                 TEST_SESSION_TOKEN,
-                                                                 TEST_STREAMING_TOKEN_DURATION,
-                                                                 TEST_DEFAULT_REGION,
-                                                                 TEST_CONTROL_PLANE_URI,
-                                                                 mCaCertPath,
-                                                                 NULL,
-                                                                 TEST_USER_AGENT,
-                                                                 API_CALL_CACHE_TYPE_NONE,
-                                                                 TEST_CACHING_ENDPOINT_PERIOD,
-                                                                 TRUE,
-                                                                 &pClientCallbacks));
-
-        addProducerCallbacks(pClientCallbacks, &producerCallbacks);
-
-        EXPECT_TRUE(clientReadyAggregate != pClientCallbacks->clientReadyFn);
-        EXPECT_TRUE(clientShutdownAggregate != producerCallbacks.clientShutdownFn);
-        EXPECT_TRUE(storageOverflowPressureAggregate != producerCallbacks.storageOverflowPressureFn);
-
-        //non-null callback definition should return aggregated platform callback
-        producerCallbacks.clientReadyFn = (UINT32 (*)(UINT64, UINT64)) 2;
-
-        addProducerCallbacks(pClientCallbacks, &producerCallbacks);
-
-        addProducerCallbacks(pClientCallbacks, &producerCallbacks);
-        EXPECT_TRUE(4 == ((PCallbacksProvider) pClientCallbacks)->producerCallbacksCount);
-
-        EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-        EXPECT_EQ(NULL, pClientCallbacks);
+        EXPECT_EQ(0, STRNCMP(pCurlApiCallbacks->controlPlaneUrl, (PCHAR) it.second.c_str(), MAX_URI_CHAR_LEN));
 
         EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 
         EXPECT_EQ(STATUS_NULL_ARG, freeCallbacksProvider(NULL));
-
     }
+}
 
-    TEST_F(ProducerCallbackProviderApiTest, TestCorrectControlPlaneUriForSpecifiedRegion)
-    {
-        PClientCallbacks pClientCallbacks = NULL;
-        // Map region to control plane url
-        std::map<std::string, std::string> regionToControlPlaneUrlMap = {
-                                    {"us-east-1", "https://kinesisvideo.us-east-1.amazonaws.com"},
-                                    {"us-west-2", "https://kinesisvideo.us-west-2.amazonaws.com"},
-                                    {"ap-northeast-1", "https://kinesisvideo.ap-northeast-1.amazonaws.com"},
-                                    {"ap-southeast-2", "https://kinesisvideo.ap-southeast-2.amazonaws.com"},
-                                    {"eu-central-1", "https://kinesisvideo.eu-central-1.amazonaws.com"},
-                                    {"eu-west-1", "https://kinesisvideo.eu-west-1.amazonaws.com"},
-                                    {"ap-northeast-2", "https://kinesisvideo.ap-northeast-2.amazonaws.com"},
-                                    {"ap-south-1", "https://kinesisvideo.ap-south-1.amazonaws.com"},
-                                    {"ap-southeast-1", "https://kinesisvideo.ap-southeast-1.amazonaws.com"},
-                                    {"ca-central-1", "https://kinesisvideo.ca-central-1.amazonaws.com"},
-                                    {"eu-north-1", "https://kinesisvideo.eu-north-1.amazonaws.com"},
-                                    {"eu-west-2", "https://kinesisvideo.eu-west-2.amazonaws.com"},
-                                    {"sa-east-1", "https://kinesisvideo.sa-east-1.amazonaws.com"},
-                                    {"us-east-2", "https://kinesisvideo.us-east-2.amazonaws.com"},
-                                    {"ap-east-1", "https://kinesisvideo.ap-east-1.amazonaws.com"},
-                                    {"af-south-1", "https://kinesisvideo.af-south-1.amazonaws.com"},
-                                    {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.c2s.ic.gov"},
-                                    {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.c2s.ic.gov"},
-                                    {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.sc2s.sgov.gov"},
-                                    {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.amazonaws.com"},
-                                    {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.amazonaws.com"},
-                                    {"cn-north-1", "https://kinesisvideo.cn-north-1.amazonaws.com.cn"},
-                                    {"cn-northwest-1", "https://kinesisvideo.cn-northwest-1.amazonaws.com.cn"},
-                                };
-
-        for (auto it : regionToControlPlaneUrlMap) {
-            EXPECT_EQ(STATUS_SUCCESS,
-                      createDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, TEST_ACCESS_KEY, TEST_SECRET_KEY, TEST_SESSION_TOKEN,
-                                                     TEST_STREAMING_TOKEN_DURATION, (PCHAR) it.first.c_str(), TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
-                                                     TEST_USER_AGENT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, TRUE,
-                                                     &pClientCallbacks));
-
-            PCallbacksProvider pCallbacksProvider = (PCallbacksProvider) pClientCallbacks;
-            PCurlApiCallbacks pCurlApiCallbacks = (PCurlApiCallbacks) pCallbacksProvider->pApiCallbacks[0].customData;
-
-            EXPECT_EQ(0, STRNCMP(pCurlApiCallbacks->controlPlaneUrl, (PCHAR) it.second.c_str(), MAX_URI_CHAR_LEN));
-
-            EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
-
-            EXPECT_EQ(STATUS_NULL_ARG, freeCallbacksProvider(NULL));
-        }
-
-    }
-
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
-
-
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerClientBasicTest.cpp
+++ b/tst/ProducerClientBasicTest.cpp
@@ -1,9 +1,12 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
 class ProducerClientBasicTest : public ProducerClientTestBase {
-public:
+  public:
     VOID initialize()
     {
         mSignalingLock = MUTEX_CREATE(FALSE);
@@ -74,27 +77,17 @@ PVOID ProducerClientBasicTest::staticCreateProducerClientRoutine(PVOID arg)
     deviceInfo.clientInfo.loggerLogLevel = GET_LOGGER_LOG_LEVEL();
     deviceInfo.clientInfo.logMetric = TRUE;
 
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-            API_CALL_CACHE_TYPE_NONE,
-            TEST_CACHING_ENDPOINT_PERIOD,
-            pTest->mRegion,
-            TEST_CONTROL_PLANE_URI,
-            pTest->mCaCertPath,
-            NULL,
-            TEST_USER_AGENT,
-            &pTest->mClientCallbacks[index]));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, pTest->mRegion,
+                                                     TEST_CONTROL_PLANE_URI, pTest->mCaCertPath, NULL, TEST_USER_AGENT,
+                                                     &pTest->mClientCallbacks[index]));
 
-    EXPECT_EQ(STATUS_SUCCESS, createStaticAuthCallbacks(pTest->mClientCallbacks[index],
-            pTest->mAccessKey,
-            pTest->mSecretKey,
-            pTest->mSessionToken,
-            MAX_UINT64,
-            &pAuthCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createStaticAuthCallbacks(pTest->mClientCallbacks[index], pTest->mAccessKey, pTest->mSecretKey, pTest->mSessionToken, MAX_UINT64,
+                                        &pAuthCallbacks));
 
     // Create the producer client
-    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(&deviceInfo,
-            pTest->mClientCallbacks[index],
-            &pTest->mClients[index]));
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(&deviceInfo, pTest->mClientCallbacks[index], &pTest->mClients[index]));
 
     trackInfo.version = TRACK_INFO_CURRENT_VERSION;
     trackInfo.trackId = DEFAULT_VIDEO_TRACK_ID;
@@ -134,7 +127,7 @@ PVOID ProducerClientBasicTest::staticCreateProducerClientRoutine(PVOID arg)
     streamInfo.streamCaps.trackInfoList = &trackInfo;
     streamInfo.streamCaps.frameOrderingMode = FRAME_ORDER_MODE_PASS_THROUGH;
     SNPRINTF(streamInfo.name, MAX_STREAM_NAME_LEN + 1, "ScaryTestStream_%u", (UINT32) index);
-	
+
     EXPECT_EQ(STATUS_SUCCESS, retStatus = createKinesisVideoStreamSync(pTest->mClients[index], &streamInfo, &pTest->mStreams[index]));
 
     ATOMIC_INCREMENT(&pTest->mActiveStreamCount);
@@ -238,11 +231,8 @@ PVOID ProducerClientBasicTest::staticProducerClientStartRoutine(PVOID arg)
 
     MEMSET(frame.frameData, 0x55, pTest->mFrameSize);
 
-    BYTE cpd[] = {0x00, 0x00, 0x00, 0x01, 0x67, 0x64, 0x00, 0x34,
-                  0xAC, 0x2B, 0x40, 0x1E, 0x00, 0x78, 0xD8, 0x08,
-                  0x80, 0x00, 0x01, 0xF4, 0x00, 0x00, 0xEA, 0x60,
-                  0x47, 0xA5, 0x50, 0x00, 0x00, 0x00, 0x01, 0x68,
-                  0xEE, 0x3C, 0xB0};
+    BYTE cpd[] = {0x00, 0x00, 0x00, 0x01, 0x67, 0x64, 0x00, 0x34, 0xAC, 0x2B, 0x40, 0x1E, 0x00, 0x78, 0xD8, 0x08, 0x80, 0x00,
+                  0x01, 0xF4, 0x00, 0x00, 0xEA, 0x60, 0x47, 0xA5, 0x50, 0x00, 0x00, 0x00, 0x01, 0x68, 0xEE, 0x3C, 0xB0};
     UINT32 cpdSize = SIZEOF(cpd);
 
     EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamFormatChanged(streamHandle, cpdSize, cpd, DEFAULT_VIDEO_TRACK_ID));
@@ -264,13 +254,8 @@ PVOID ProducerClientBasicTest::staticProducerClientStartRoutine(PVOID arg)
         // Key frame every 50th
         frame.flags = (frame.index % TEST_KEY_FRAME_INTERVAL == 0) ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
 
-        DLOGD("Putting frame for stream: %s, TID: 0x%" PRIx64 ", Id: %u, Key Frame: %s, Size: %u, Dts: %" PRIu64 ", Pts: %" PRIu64,
-              pStreamInfo->name,
-              tid,
-              frame.index,
-              (((frame.flags & FRAME_FLAG_KEY_FRAME) == FRAME_FLAG_KEY_FRAME) ? "true" : "false"),
-              frame.size,
-              frame.decodingTs,
+        DLOGD("Putting frame for stream: %s, TID: 0x%" PRIx64 ", Id: %u, Key Frame: %s, Size: %u, Dts: %" PRIu64 ", Pts: %" PRIu64, pStreamInfo->name,
+              tid, frame.index, (((frame.flags & FRAME_FLAG_KEY_FRAME) == FRAME_FLAG_KEY_FRAME) ? "true" : "false"), frame.size, frame.decodingTs,
               frame.presentationTs);
 
         // Apply some non-persistent metadata every few frames
@@ -280,10 +265,8 @@ PVOID ProducerClientBasicTest::staticProducerClientStartRoutine(PVOID arg)
 
             metadataName << "MetadataNameForFrame_" << frame.index;
             metadataValue << "MetadataValueForFrame_" << frame.index;
-            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(streamHandle,
-                                                                      (PCHAR) metadataName.str().c_str(),
-                                                                      (PCHAR) metadataValue.str().c_str(),
-                                                                      FALSE));
+            EXPECT_EQ(STATUS_SUCCESS,
+                      putKinesisVideoFragmentMetadata(streamHandle, (PCHAR) metadataName.str().c_str(), (PCHAR) metadataValue.str().c_str(), FALSE));
         }
 
         // Apply some persistent metadata on a larger intervals to span fragments
@@ -300,10 +283,9 @@ PVOID ProducerClientBasicTest::staticProducerClientStartRoutine(PVOID arg)
             }
 
             persistentMetadataIndex++;
-            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(streamHandle,
-                                                                      (PCHAR) persistentMetadataName.c_str(),
-                                                                      (PCHAR) metadataValue.str().c_str(),
-                                                                      TRUE));
+            EXPECT_EQ(
+                STATUS_SUCCESS,
+                putKinesisVideoFragmentMetadata(streamHandle, (PCHAR) persistentMetadataName.c_str(), (PCHAR) metadataValue.str().c_str(), TRUE));
         }
 
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &frame));
@@ -369,11 +351,8 @@ PVOID ProducerClientTestBase::basicProducerRoutine(STREAM_HANDLE streamHandle, S
 
     MEMSET(frame.frameData, 0x55, mFrameSize);
 
-    BYTE cpd[] = {0x00, 0x00, 0x00, 0x01, 0x67, 0x64, 0x00, 0x34,
-                  0xAC, 0x2B, 0x40, 0x1E, 0x00, 0x78, 0xD8, 0x08,
-                  0x80, 0x00, 0x01, 0xF4, 0x00, 0x00, 0xEA, 0x60,
-                  0x47, 0xA5, 0x50, 0x00, 0x00, 0x00, 0x01, 0x68,
-                  0xEE, 0x3C, 0xB0};
+    BYTE cpd[] = {0x00, 0x00, 0x00, 0x01, 0x67, 0x64, 0x00, 0x34, 0xAC, 0x2B, 0x40, 0x1E, 0x00, 0x78, 0xD8, 0x08, 0x80, 0x00,
+                  0x01, 0xF4, 0x00, 0x00, 0xEA, 0x60, 0x47, 0xA5, 0x50, 0x00, 0x00, 0x00, 0x01, 0x68, 0xEE, 0x3C, 0xB0};
     UINT32 cpdSize = SIZEOF(cpd);
 
     EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamFormatChanged(streamHandle, cpdSize, cpd, DEFAULT_VIDEO_TRACK_ID));
@@ -399,13 +378,8 @@ PVOID ProducerClientTestBase::basicProducerRoutine(STREAM_HANDLE streamHandle, S
         // Key frame every 50th
         frame.flags = (frame.index % TEST_KEY_FRAME_INTERVAL == 0) ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
 
-        DLOGD("Putting frame for stream: %s, TID: 0x%" PRIx64 ", Id: %u, Key Frame: %s, Size: %u, Dts: %" PRIu64 ", Pts: %" PRIu64,
-              pStreamInfo->name,
-              tid,
-              frame.index,
-              (((frame.flags & FRAME_FLAG_KEY_FRAME) == FRAME_FLAG_KEY_FRAME) ? "true" : "false"),
-              frame.size,
-              frame.decodingTs,
+        DLOGD("Putting frame for stream: %s, TID: 0x%" PRIx64 ", Id: %u, Key Frame: %s, Size: %u, Dts: %" PRIu64 ", Pts: %" PRIu64, pStreamInfo->name,
+              tid, frame.index, (((frame.flags & FRAME_FLAG_KEY_FRAME) == FRAME_FLAG_KEY_FRAME) ? "true" : "false"), frame.size, frame.decodingTs,
               frame.presentationTs);
         // Apply some non-persistent metadata every few frames
         if (frame.index % 20 == 0) {
@@ -413,10 +387,8 @@ PVOID ProducerClientTestBase::basicProducerRoutine(STREAM_HANDLE streamHandle, S
             std::ostringstream metadataValue;
             metadataName << "MetadataNameForFrame_" << frame.index;
             metadataValue << "MetadataValueForFrame_" << frame.index;
-            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(streamHandle,
-                                                                      (PCHAR) metadataName.str().c_str(),
-                                                                      (PCHAR) metadataValue.str().c_str(),
-                                                                      FALSE));
+            EXPECT_EQ(STATUS_SUCCESS,
+                      putKinesisVideoFragmentMetadata(streamHandle, (PCHAR) metadataName.str().c_str(), (PCHAR) metadataValue.str().c_str(), FALSE));
         }
 
         // Apply some persistent metadata on a larger intervals to span fragments
@@ -433,10 +405,9 @@ PVOID ProducerClientTestBase::basicProducerRoutine(STREAM_HANDLE streamHandle, S
             }
 
             persistentMetadataIndex++;
-            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(streamHandle,
-                                                                      (PCHAR) persistentMetadataName.c_str(),
-                                                                      (PCHAR) metadataValue.str().c_str(),
-                                                                      TRUE));
+            EXPECT_EQ(
+                STATUS_SUCCESS,
+                putKinesisVideoFragmentMetadata(streamHandle, (PCHAR) persistentMetadataName.c_str(), (PCHAR) metadataValue.str().c_str(), TRUE));
         }
 
 #if 0
@@ -451,9 +422,9 @@ EXPECT_TRUE(kinesis_video_stream->putFrame(eofr));
 
         // Sleep a while for non-offline modes
         if (streamingType != STREAMING_TYPE_OFFLINE) {
-            diffTime = GETTIME()-timestamp;
+            diffTime = GETTIME() - timestamp;
             if (diffTime < TEST_FRAME_DURATION) {
-                THREAD_SLEEP(TEST_FRAME_DURATION-diffTime);
+                THREAD_SLEEP(TEST_FRAME_DURATION - diffTime);
             }
         }
     }
@@ -478,7 +449,8 @@ TEST_F(ProducerClientBasicTest, create_produce_stream)
 
     for (UINT32 i = 0; i < TEST_STREAM_COUNT; i++) {
         // Create the stream
-        ASSERT_EQ(STATUS_SUCCESS, createTestStream(i, STREAMING_TYPE_REALTIME, 20 * HUNDREDS_OF_NANOS_IN_A_SECOND, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+        ASSERT_EQ(STATUS_SUCCESS,
+                  createTestStream(i, STREAMING_TYPE_REALTIME, 20 * HUNDREDS_OF_NANOS_IN_A_SECOND, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND));
 
         // Spin off the producer
         EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE(&mProducerThread, staticProducerRoutine, (PVOID) mStreams[i]));
@@ -521,7 +493,7 @@ TEST_F(ProducerClientBasicTest, create_produce_stream)
 #endif
 
     // Wait for some time to produce
-    THREAD_SLEEP(2*TEST_EXECUTION_DURATION);
+    THREAD_SLEEP(2 * TEST_EXECUTION_DURATION);
 
     // Indicate the cancel for the threads
     ATOMIC_STORE_BOOL(&mStopProducer, TRUE);
@@ -576,7 +548,7 @@ TEST_F(ProducerClientBasicTest, create_produce_stream_parallel)
     }
 
     // Wait for some time to produce
-    THREAD_SLEEP(2*TEST_EXECUTION_DURATION);
+    THREAD_SLEEP(2 * TEST_EXECUTION_DURATION);
 
     // Indicate the cancel for the threads
     ATOMIC_STORE_BOOL(&mStopProducer, TRUE);
@@ -622,7 +594,7 @@ TEST_F(ProducerClientBasicTest, create_produce_client_parallel)
     }
 
     // Wait for some time to produce
-    THREAD_SLEEP(2*TEST_EXECUTION_DURATION);
+    THREAD_SLEEP(2 * TEST_EXECUTION_DURATION);
 
     // Indicate the cancel for the threads
     ATOMIC_STORE_BOOL(&mStopProducer, TRUE);
@@ -654,7 +626,8 @@ TEST_F(ProducerClientBasicTest, cachingEndpointProvider_Returns_EndpointFromCach
 
     for (UINT32 i = 0; i < TEST_STREAM_COUNT; i++) {
         // Create the stream
-        ASSERT_EQ(STATUS_SUCCESS, createTestStream(i, STREAMING_TYPE_REALTIME, 20 * HUNDREDS_OF_NANOS_IN_A_SECOND, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+        ASSERT_EQ(STATUS_SUCCESS,
+                  createTestStream(i, STREAMING_TYPE_REALTIME, 20 * HUNDREDS_OF_NANOS_IN_A_SECOND, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND));
 
         // Spin off the producer
         EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE(&mProducerThread, staticProducerRoutine, (PVOID) mStreams[i]));
@@ -711,13 +684,10 @@ TEST_F(ProducerClientBasicTest, createStreamStopSyncFree)
     pDeviceInfo->clientInfo.loggerLogLevel = GET_LOGGER_LOG_LEVEL();
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
-
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(5, mAccessKey, mSecretKey,
-                                                             mSessionToken, GETTIME() + TEST_STREAMING_TOKEN_DURATION,
-                                                             mRegion, TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath, NULL, NULL,
-                                                             API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
-                                                             FALSE, &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(5, mAccessKey, mSecretKey, mSessionToken, GETTIME() + TEST_STREAMING_TOKEN_DURATION, mRegion,
+                                             TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                             FALSE, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
     EXPECT_EQ(STATUS_SUCCESS, stopKinesisVideoStreamSync(streamHandle));
@@ -747,19 +717,16 @@ TEST_F(ProducerClientBasicTest, createStreamPutOneFrameStopSyncFree)
     frame.size = mFrameSize;
     frame.flags = FRAME_FLAG_KEY_FRAME;
 
-
     STRNCPY(streamName, (PCHAR) TEST_STREAM_NAME, MAX_STREAM_NAME_LEN);
     streamName[MAX_STREAM_NAME_LEN] = '\0';
     EXPECT_EQ(STATUS_SUCCESS, createDefaultDeviceInfo(&pDeviceInfo));
     pDeviceInfo->clientInfo.loggerLogLevel = GET_LOGGER_LOG_LEVEL();
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
     pStreamInfo->streamCaps.nalAdaptationFlags = NAL_ADAPTATION_FLAG_NONE;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(5, mAccessKey, mSecretKey,
-                                                             mSessionToken, GETTIME() + TEST_STREAMING_TOKEN_DURATION,
-                                                             mRegion, TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath, NULL, NULL,
-                                                             API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
-                                                             FALSE, &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(5, mAccessKey, mSecretKey, mSessionToken, GETTIME() + TEST_STREAMING_TOKEN_DURATION, mRegion,
+                                             TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
+                                             FALSE, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
     EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &frame));
@@ -792,23 +759,19 @@ TEST_F(ProducerClientBasicTest, createStreamPutMultipleFrameStopSyncFree)
     frame.size = mFrameSize;
     frame.flags = FRAME_FLAG_KEY_FRAME;
 
-
     STRNCPY(streamName, (PCHAR) TEST_STREAM_NAME, MAX_STREAM_NAME_LEN);
     streamName[MAX_STREAM_NAME_LEN] = '\0';
     EXPECT_EQ(STATUS_SUCCESS, createDefaultDeviceInfo(&pDeviceInfo));
     pDeviceInfo->clientInfo.loggerLogLevel = GET_LOGGER_LOG_LEVEL();
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
     pStreamInfo->streamCaps.nalAdaptationFlags = NAL_ADAPTATION_FLAG_NONE;
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(5, mAccessKey, mSecretKey,
-                                                             mSessionToken, MAX_UINT64,
-                                                             mRegion, TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath, NULL, NULL,
-                                                             API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD,
-                                                             FALSE, &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(5, mAccessKey, mSecretKey, mSessionToken, MAX_UINT64, mRegion, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             NULL, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, FALSE, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
 
-    for(i = 0; i < TEST_START_STOP_ITERATION_COUNT; i++) {
+    for (i = 0; i < TEST_START_STOP_ITERATION_COUNT; i++) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &frame));
         THREAD_SLEEP(TEST_FRAME_DURATION);
         frame.index++;
@@ -836,9 +799,7 @@ TEST_F(ProducerClientBasicTest, createStreamStreamUntilTokenRotationStopSyncFree
     CHAR streamName[MAX_STREAM_NAME_LEN + 1];
     Frame frame;
     UINT64 currentTime = GETTIME();
-    UINT64 stopTime = currentTime +
-                      TEST_STREAMING_TOKEN_DURATION +
-                      10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    UINT64 stopTime = currentTime + TEST_STREAMING_TOKEN_DURATION + 10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
 
     frame.version = FRAME_CURRENT_VERSION;
     frame.duration = TEST_FRAME_DURATION;
@@ -856,30 +817,20 @@ TEST_F(ProducerClientBasicTest, createStreamStreamUntilTokenRotationStopSyncFree
     pDeviceInfo->clientInfo.loggerLogLevel = GET_LOGGER_LOG_LEVEL();
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
     pStreamInfo->streamCaps.nalAdaptationFlags = NAL_ADAPTATION_FLAG_NONE;
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-            API_CALL_CACHE_TYPE_NONE,
-            TEST_CACHING_ENDPOINT_PERIOD,
-            mRegion,
-            TEST_CONTROL_PLANE_URI,
-            mCaCertPath,
-            NULL,
-            NULL,
-            &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
 
     UINT64 expiration = currentTime + TEST_STREAMING_TOKEN_DURATION;
 
-    EXPECT_EQ(STATUS_SUCCESS, createRotatingStaticAuthCallbacks(pClientCallbacks,
-                                                                mAccessKey,
-                                                                mSecretKey,
-                                                                mSessionToken,
-                                                                expiration,
-                                                                TEST_STREAMING_TOKEN_DURATION,
-                                                                &pAuthCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRotatingStaticAuthCallbacks(pClientCallbacks, mAccessKey, mSecretKey, mSessionToken, expiration, TEST_STREAMING_TOKEN_DURATION,
+                                                &pAuthCallbacks));
 
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
 
-    while(currentTime < stopTime) {
+    while (currentTime < stopTime) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &frame));
         THREAD_SLEEP(TEST_FRAME_DURATION);
         frame.index++;
@@ -908,9 +859,7 @@ TEST_F(ProducerClientBasicTest, createStreamStreamUntilTokenRotationStopSyncFree
     CHAR streamName[MAX_STREAM_NAME_LEN + 1];
     Frame frame;
     UINT64 currentTime = GETTIME();
-    UINT64 stopTime = currentTime +
-                      TEST_STREAMING_TOKEN_DURATION +
-                      10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    UINT64 stopTime = currentTime + TEST_STREAMING_TOKEN_DURATION + 10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
 
     frame.version = FRAME_CURRENT_VERSION;
     frame.duration = TEST_FRAME_DURATION;
@@ -928,31 +877,21 @@ TEST_F(ProducerClientBasicTest, createStreamStreamUntilTokenRotationStopSyncFree
     pDeviceInfo->clientInfo.loggerLogLevel = GET_LOGGER_LOG_LEVEL();
     EXPECT_EQ(STATUS_SUCCESS, createRealtimeVideoStreamInfoProvider(streamName, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
     pStreamInfo->streamCaps.nalAdaptationFlags = NAL_ADAPTATION_FLAG_NONE;
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     API_CALL_CACHE_TYPE_NONE,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     mRegion,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     mCaCertPath,
-                                                                     NULL,
-                                                                     NULL,
-                                                                     &pClientCallbacks));
-    EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, 100*1024, 3, (PCHAR) "/tmp", TRUE));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, NULL, &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS, addFileLoggerPlatformCallbacksProvider(pClientCallbacks, 100 * 1024, 3, (PCHAR) "/tmp", TRUE));
 
     UINT64 expiration = currentTime + TEST_STREAMING_TOKEN_DURATION;
 
-    EXPECT_EQ(STATUS_SUCCESS, createRotatingStaticAuthCallbacks(pClientCallbacks,
-                                                                mAccessKey,
-                                                                mSecretKey,
-                                                                mSessionToken,
-                                                                expiration,
-                                                                TEST_STREAMING_TOKEN_DURATION,
-                                                                &pAuthCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRotatingStaticAuthCallbacks(pClientCallbacks, mAccessKey, mSecretKey, mSessionToken, expiration, TEST_STREAMING_TOKEN_DURATION,
+                                                &pAuthCallbacks));
 
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
 
-    while(currentTime < stopTime) {
+    while (currentTime < stopTime) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &frame));
         THREAD_SLEEP(TEST_FRAME_DURATION);
         frame.index++;
@@ -1008,16 +947,13 @@ TEST_F(ProducerClientBasicTest, createStreamPutMultipleFrameTimeoutLatencyStopSy
     pStreamInfo->streamCaps.frameRate = frameRate;
     pStreamInfo->streamCaps.frameTimecodes = TRUE;
 
-    EXPECT_EQ(STATUS_SUCCESS, createDefaultCallbacksProvider(5, mAccessKey, mSecretKey,
-                                                             mSessionToken, MAX_UINT64,
-                                                             mRegion, TEST_CONTROL_PLANE_URI,
-                                                             mCaCertPath, NULL, NULL,
-                                                             API_CALL_CACHE_TYPE_ALL, TEST_CACHING_ENDPOINT_PERIOD,
-                                                             TRUE, &pClientCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createDefaultCallbacksProvider(5, mAccessKey, mSecretKey, mSessionToken, MAX_UINT64, mRegion, TEST_CONTROL_PLANE_URI, mCaCertPath, NULL,
+                                             NULL, API_CALL_CACHE_TYPE_ALL, TEST_CACHING_ENDPOINT_PERIOD, TRUE, &pClientCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClientSync(pDeviceInfo, pClientCallbacks, &clientHandle));
     EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(clientHandle, pStreamInfo, &streamHandle));
 
-    for(i = 0; i < fragmentCount * keyFrameInterval; i++) {
+    for (i = 0; i < fragmentCount * keyFrameInterval; i++) {
         frame.flags = frame.index % keyFrameInterval == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
 
         if (i == keyFrameInterval && frame.flags == FRAME_FLAG_KEY_FRAME) {
@@ -1043,7 +979,7 @@ TEST_F(ProducerClientBasicTest, createStreamPutMultipleFrameTimeoutLatencyStopSy
     EXPECT_EQ(STATUS_SUCCESS, freeCallbacksProvider(&pClientCallbacks));
 }
 
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerClientFaultInjectionTest.cpp
+++ b/tst/ProducerClientFaultInjectionTest.cpp
@@ -1,9 +1,11 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class ProducerClientFaultInjectionTest : public ProducerClientTestBase {
-};
+class ProducerClientFaultInjectionTest : public ProducerClientTestBase {};
 
 TEST_F(ProducerClientFaultInjectionTest, notAuthorizedDescribeCall)
 {
@@ -281,7 +283,8 @@ TEST_F(ProducerClientFaultInjectionTest, timeoutCreateCallWithContinuousCallback
     mCreateStreamCallResult = SERVICE_CALL_NETWORK_CONNECTION_TIMEOUT;
 
     // Attempt to create a stream
-    EXPECT_EQ(STATUS_OPERATION_TIMED_OUT, createTestStream(0, STREAMING_TYPE_REALTIME, 20 * HUNDREDS_OF_NANOS_IN_A_SECOND, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+    EXPECT_EQ(STATUS_OPERATION_TIMED_OUT,
+              createTestStream(0, STREAMING_TYPE_REALTIME, 20 * HUNDREDS_OF_NANOS_IN_A_SECOND, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND));
 
     THREAD_SLEEP(2 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
@@ -552,7 +555,7 @@ TEST_F(ProducerClientFaultInjectionTest, timeoutPutMediaCall)
     freeStreams();
 }
 
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerContinuousRetryTest.cpp
+++ b/tst/ProducerContinuousRetryTest.cpp
@@ -1,13 +1,16 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
-    
-class ProducerContinuousRetryTest : public ProducerClientTestBase {
-};
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+
+class ProducerContinuousRetryTest : public ProducerClientTestBase {};
 
 extern ProducerClientTestBase* gProducerClientTestBase;
 
-TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_connection_stale_triggered) {
+TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_connection_stale_triggered)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10; // 130s in total duration
@@ -27,7 +30,7 @@ TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_connection_stale_trigg
     streamHandle = mStreams[0];
     EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -45,7 +48,8 @@ TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_connection_stale_trigg
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_stream_latency_triggered) {
+TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_stream_latency_triggered)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10; // 10s in total duration
@@ -63,7 +67,7 @@ TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_stream_latency_trigger
     streamHandle = mStreams[0];
     EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
 
-    for(i = 0; i < totalFrames - 1; ++i) {
+    for (i = 0; i < totalFrames - 1; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
     }
@@ -83,7 +87,8 @@ TEST_F(ProducerContinuousRetryTest, test_stream_callbacks_stream_latency_trigger
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection) {
+TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10; // 10s in total duration
@@ -97,7 +102,7 @@ TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection)
     streamHandle = mStreams[0];
     EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -106,7 +111,7 @@ TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection)
     kinesisVideoStreamResetConnection(streamHandle);
 
     THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -119,7 +124,8 @@ TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection)
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection_stream_session_timeout) {
+TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection_stream_session_timeout)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10; // 10s in total duration
@@ -133,7 +139,7 @@ TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection_
     streamHandle = mStreams[0];
     EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -142,7 +148,7 @@ TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection_
     kinesisVideoStreamResetConnection(streamHandle);
 
     THREAD_SLEEP(31 * HUNDREDS_OF_NANOS_IN_A_SECOND);
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -155,7 +161,8 @@ TEST_F(ProducerContinuousRetryTest, test_stream_recover_after_reset_connnection_
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, recover_on_retriable_producer_error) {
+TEST_F(ProducerContinuousRetryTest, recover_on_retriable_producer_error)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10;
@@ -182,7 +189,7 @@ TEST_F(ProducerContinuousRetryTest, recover_on_retriable_producer_error) {
     pAuth->recoverCount = 3; // 1 for main token, 1 for the security token for the first session
     // and only then should fail for the last token.
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -202,7 +209,8 @@ TEST_F(ProducerContinuousRetryTest, recover_on_retriable_producer_error) {
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_producer_error) {
+TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_producer_error)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10;
@@ -229,7 +237,7 @@ TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_producer_error)
     pAuth->recoverCount = 3; // 1 for main token, 1 for the security token for the first session
     // and only then should fail for the last token.
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -246,7 +254,8 @@ TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_producer_error)
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, recover_on_retriable_common_lib_error) {
+TEST_F(ProducerContinuousRetryTest, recover_on_retriable_common_lib_error)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10;
@@ -273,7 +282,7 @@ TEST_F(ProducerContinuousRetryTest, recover_on_retriable_common_lib_error) {
     pAuth->recoverCount = 3; // 1 for main token, 1 for the security token for the first session
     // and only then should fail for the last token.
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -290,7 +299,8 @@ TEST_F(ProducerContinuousRetryTest, recover_on_retriable_common_lib_error) {
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_common_lib_error) {
+TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_common_lib_error)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10;
@@ -317,7 +327,7 @@ TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_common_lib_erro
     pAuth->recoverCount = 3; // 1 for main token, 1 for the security token for the first session
     // and only then should fail for the last token.
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -334,7 +344,8 @@ TEST_F(ProducerContinuousRetryTest, no_recovery_on_non_retriable_common_lib_erro
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-TEST_F(ProducerContinuousRetryTest, contrinuous_retry_reset_failure) {
+TEST_F(ProducerContinuousRetryTest, contrinuous_retry_reset_failure)
+{
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     UINT32 i;
     UINT32 totalFragments = 10;
@@ -364,7 +375,7 @@ TEST_F(ProducerContinuousRetryTest, contrinuous_retry_reset_failure) {
     mDescribeRecoverCount = 1000;
     mDescribeRetStatus = STATUS_DESCRIBE_STREAM_CALL_FAILED;
 
-    for(i = 0; i < totalFrames; ++i) {
+    for (i = 0; i < totalFrames; ++i) {
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         updateFrame();
         THREAD_SLEEP(mFrame.duration / 2); // speed up test
@@ -393,7 +404,7 @@ TEST_F(ProducerContinuousRetryTest, contrinuous_retry_reset_failure) {
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-}
-}
-}
-}
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerFunctionalityTest.cpp
+++ b/tst/ProducerFunctionalityTest.cpp
@@ -1,15 +1,17 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
-class ProducerFunctionalityTest : public ProducerClientTestBase {
-};
+class ProducerFunctionalityTest : public ProducerClientTestBase {};
 
 extern ProducerClientTestBase* gProducerClientTestBase;
 
-#define FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT    30 * HUNDREDS_OF_NANOS_IN_A_SECOND
-#define FUNCTIONALITY_TEST_STOP_STREAM_TIMEOUT      60 * HUNDREDS_OF_NANOS_IN_A_SECOND
-#define FUNCTIONALITY_TEST_STRESS_TEST_ITERATION    3
+#define FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT 30 * HUNDREDS_OF_NANOS_IN_A_SECOND
+#define FUNCTIONALITY_TEST_STOP_STREAM_TIMEOUT   60 * HUNDREDS_OF_NANOS_IN_A_SECOND
+#define FUNCTIONALITY_TEST_STRESS_TEST_ITERATION 3
 
 TEST_F(ProducerFunctionalityTest, start_stopsync_terminate)
 {
@@ -88,7 +90,6 @@ TEST_F(ProducerFunctionalityTest, reset_stream_on_stream_error_before_putFrame)
     EXPECT_LT(0, mFragmentAckReceivedFnCount);
     EXPECT_EQ(totalFragments, mPersistedFragmentCount);
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
-
 }
 
 TEST_F(ProducerFunctionalityTest, reset_stream_on_stream_error_with_frame_in_buffer)
@@ -137,7 +138,6 @@ TEST_F(ProducerFunctionalityTest, reset_stream_on_stream_error_with_frame_in_buf
     // some fragments are gonna be dropped when resetStream is triggered.
     EXPECT_LT(mPersistedFragmentCount, totalFragments);
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
-
 }
 
 TEST_F(ProducerFunctionalityTest, repeated_create_client_create_stream_sync_and_free_everything)
@@ -272,7 +272,6 @@ TEST_F(ProducerFunctionalityTest, create_client_repeated_create_stream_put_frame
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
     for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
-
         EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
         streamHandle = mStreams[0];
         EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
@@ -306,7 +305,6 @@ TEST_F(ProducerFunctionalityTest, create_caching_endpoint_repeated_create_stream
     createDefaultProducerClient(TRUE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
     for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
-
         EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
         streamHandle = mStreams[0];
         EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
@@ -372,7 +370,6 @@ TEST_F(ProducerFunctionalityTest, create_caching_all_repeated_create_stream_put_
     createDefaultProducerClient(API_CALL_CACHE_TYPE_ALL, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
     for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
-
         EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
         streamHandle = mStreams[0];
         EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
@@ -439,11 +436,8 @@ TEST_F(ProducerFunctionalityTest, create_client_repeated_create_stream_put_frame
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
     for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
-
         for (j = 0; j < streamCount; j++) {
-            EXPECT_EQ(STATUS_SUCCESS,
-                      createTestStream(j, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION,
-                                       FALSE));
+            EXPECT_EQ(STATUS_SUCCESS, createTestStream(j, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
             EXPECT_TRUE(mStreams[j] != INVALID_STREAM_HANDLE_VALUE);
         }
 
@@ -464,10 +458,7 @@ TEST_F(ProducerFunctionalityTest, create_client_repeated_create_stream_put_frame
 
         // Spin off threads to stop sync
         for (j = 0; j < streamCount; j++) {
-            EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE(
-                    &threadIds[j],
-                    stopRoutine,
-                    (PVOID) mStreams[j]));
+            EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE(&threadIds[j], stopRoutine, (PVOID) mStreams[j]));
         }
 
         // Await for every one of the threads
@@ -492,7 +483,6 @@ TEST_F(ProducerFunctionalityTest, create_client_repeated_create_stream_put_frame
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
     for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
-
         EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
         streamHandle = mStreams[0];
         EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
@@ -522,7 +512,6 @@ TEST_F(ProducerFunctionalityTest, create_client_repeated_create_stream_put_frame
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
     for (i = 0; i < FUNCTIONALITY_TEST_STRESS_TEST_ITERATION; i++) {
-
         for (j = 0; j < streamCount; j++) {
             EXPECT_EQ(STATUS_SUCCESS, createTestStream(j, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION, FALSE));
             EXPECT_TRUE(mStreams[j] != INVALID_STREAM_HANDLE_VALUE);
@@ -706,7 +695,7 @@ TEST_F(ProducerFunctionalityTest, intermittent_producer_verify_eofr_sent)
         startTime = GETTIME();
         // i = 480 will be start of a key frame, if I don't start on key-frame
         // this test fails
-        if( (i < 30) || (i >= 480) ) {
+        if ((i < 30) || (i >= 480)) {
             EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
         }
         updateFrame();
@@ -736,14 +725,10 @@ TEST_F(ProducerFunctionalityTest, intermittent_producer_verify_eofr_sent_multi_t
     mKeyFrameInterval = 10;
     UPLOAD_HANDLE streamUploadHandle = 0;
 
-
     PStreamInfo pStreamInfo;
 
     EXPECT_EQ(STATUS_SUCCESS,
-            createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME,
-                                                       TEST_RETENTION_PERIOD,
-                                                       TEST_STREAM_BUFFER_DURATION,
-                                                       &pStreamInfo));
+              createRealtimeAudioVideoStreamInfoProvider(TEST_STREAM_NAME, TEST_RETENTION_PERIOD, TEST_STREAM_BUFFER_DURATION, &pStreamInfo));
 
     EXPECT_EQ(FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_PTS_ONE_MS_COMPENSATE_EOFR, pStreamInfo->streamCaps.frameOrderingMode);
     EXPECT_EQ(2, pStreamInfo->streamCaps.trackInfoCount);
@@ -767,7 +752,7 @@ TEST_F(ProducerFunctionalityTest, intermittent_producer_verify_eofr_sent_multi_t
         startTime = GETTIME();
         // i = 480 will be start of a key frame, if I don't start on key-frame
         // this test fails
-        if ( (i < 30) || (i >= 480) ) {
+        if ((i < 30) || (i >= 480)) {
             mFrame.trackId = TEST_VIDEO_TRACK_ID;
             EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &mFrame));
             mFrame.trackId = TEST_AUDIO_TRACK_ID;
@@ -795,7 +780,6 @@ TEST_F(ProducerFunctionalityTest, intermittent_producer_verify_eofr_sent_multi_t
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-
 TEST_F(ProducerFunctionalityTest, pressure_on_buffer_duration_fail_new_connection_at_token_rotation)
 {
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
@@ -804,7 +788,8 @@ TEST_F(ProducerFunctionalityTest, pressure_on_buffer_duration_fail_new_connectio
     UINT32 totalFrames = totalFragments * TEST_FPS;
     mCurlEasyPerformInjectionCount = 1;
 
-    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE, 45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE,
+                                45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, 10 * HUNDREDS_OF_NANOS_IN_A_SECOND));
     streamHandle = mStreams[0];
@@ -838,7 +823,8 @@ TEST_F(ProducerFunctionalityTest, pressure_on_buffer_duration_fail_old_connectio
     UINT32 totalFragments = 120, errCount;
     UINT32 totalFrames = totalFragments * TEST_FPS;
 
-    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE, 45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE,
+                                45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, 10 * HUNDREDS_OF_NANOS_IN_A_SECOND));
     streamHandle = mStreams[0];
@@ -878,7 +864,8 @@ TEST_F(ProducerFunctionalityTest, pressure_on_storage_fail_new_connection_at_tok
     BYTE tempBuf[10000];
 
     mDeviceInfo.storageInfo.storageSize = 1 * 1024 * 1024;
-    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE, 45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE,
+                                45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, MAX_UINT64, 240 * HUNDREDS_OF_NANOS_IN_A_SECOND));
     streamHandle = mStreams[0];
@@ -921,7 +908,8 @@ TEST_F(ProducerFunctionalityTest, pressure_on_storage_fail_old_connection_at_tok
 
     mDeviceInfo.storageInfo.storageSize = 1 * 1024 * 1024;
     mStreamInfo.streamCaps.replayDuration = 240 * HUNDREDS_OF_NANOS_IN_A_SECOND;
-    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE, 45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE,
+                                45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, 240 * HUNDREDS_OF_NANOS_IN_A_SECOND));
     streamHandle = mStreams[0];
@@ -987,7 +975,8 @@ TEST_F(ProducerFunctionalityTest, offline_upload_limited_storage)
     UINT32 totalFrames = totalFragments * TEST_FPS;
 
     mDeviceInfo.storageInfo.storageSize = 1 * 1024 * 1024;
-    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE, 45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND, TRUE,
+                                45 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_OFFLINE, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION));
     streamHandle = mStreams[0];
@@ -1314,15 +1303,9 @@ TEST_F(ProducerFunctionalityTest, DISABLED_offline_mode_multiple_stream_streamin
 TEST_F(ProducerFunctionalityTest, create_abstract_provider_add_stream_callback_free_provider)
 {
     PStreamCallbacks pStreamCallbacks;
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     API_CALL_CACHE_TYPE_NONE,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     mRegion,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     mCaCertPath,
-                                                                     NULL,
-                                                                     TEST_USER_AGENT,
-                                                                     &mCallbacksProvider));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, API_CALL_CACHE_TYPE_NONE, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, TEST_USER_AGENT, &mCallbacksProvider));
     EXPECT_EQ(STATUS_SUCCESS, createStreamCallbacks(&pStreamCallbacks));
     EXPECT_EQ(STATUS_SUCCESS, addStreamCallbacks(mCallbacksProvider, pStreamCallbacks));
 
@@ -1837,7 +1820,6 @@ TEST_F(ProducerFunctionalityTest, putFrame_stopSync_timeout_reset_then_putFrame_
     mStreams[0] = INVALID_STREAM_HANDLE_VALUE;
 }
 
-
 TEST_F(ProducerFunctionalityTest, putFrame_stopSync_reset_then_putFrame_again_multistream)
 {
     UINT32 j, i;
@@ -2064,7 +2046,7 @@ TEST_F(ProducerFunctionalityTest, dropTailFragPolicyBufferOverflowNoInvalidMkv)
     EXPECT_GT(mPersistedFragmentCount, 0);
 }
 
-}
-}
-}
-}
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/ProducerTestFixture.cpp
+++ b/tst/ProducerTestFixture.cpp
@@ -1,6 +1,9 @@
 #include "ProducerTestFixture.h"
 
-namespace com { namespace amazonaws { namespace kinesis { namespace video {
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
 
 //
 // Global memory allocation counter
@@ -17,12 +20,10 @@ MUTEX gProducerClientMemMutex;
 //
 ProducerClientTestBase* gProducerClientTestBase;
 
-STATUS ProducerClientTestBase::testBufferDurationOverflowFunc(UINT64 customData,
-                                          STREAM_HANDLE streamHandle,
-                                          UINT64 remainDuration)
+STATUS ProducerClientTestBase::testBufferDurationOverflowFunc(UINT64 customData, STREAM_HANDLE streamHandle, UINT64 remainDuration)
 {
-    DLOGD("Reported bufferDurationOverflow callback for stream handle %" PRIu64 ". Remaining duration in 100ns: %" PRIu64,
-          streamHandle, remainDuration);
+    DLOGD("Reported bufferDurationOverflow callback for stream handle %" PRIu64 ". Remaining duration in 100ns: %" PRIu64, streamHandle,
+          remainDuration);
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     MUTEX_LOCK(pTest->mTestCallbackLock);
     pTest->mBufferDurationOverflowFnCount++;
@@ -31,12 +32,10 @@ STATUS ProducerClientTestBase::testBufferDurationOverflowFunc(UINT64 customData,
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testStreamLatencyPressureFunc(UINT64 customData,
-                                         STREAM_HANDLE streamHandle,
-                                         UINT64 currentBufferDuration)
+STATUS ProducerClientTestBase::testStreamLatencyPressureFunc(UINT64 customData, STREAM_HANDLE streamHandle, UINT64 currentBufferDuration)
 {
-    DLOGD("Reported streamLatencyPressure callback for stream handle %" PRIu64 ". Current buffer duration in 100ns: %" PRIu64,
-          streamHandle, currentBufferDuration);
+    DLOGD("Reported streamLatencyPressure callback for stream handle %" PRIu64 ". Current buffer duration in 100ns: %" PRIu64, streamHandle,
+          currentBufferDuration);
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     MUTEX_LOCK(pTest->mTestCallbackLock);
     pTest->mStreamLatencyPressureFnCount++;
@@ -44,12 +43,10 @@ STATUS ProducerClientTestBase::testStreamLatencyPressureFunc(UINT64 customData,
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testStreamConnectionStaleFunc(UINT64 customData,
-                                         STREAM_HANDLE streamHandle,
-                                         UINT64 timeSinceLastBufferingAck)
+STATUS ProducerClientTestBase::testStreamConnectionStaleFunc(UINT64 customData, STREAM_HANDLE streamHandle, UINT64 timeSinceLastBufferingAck)
 {
-    DLOGD("Reported streamConnectionStale callback for stream handle %" PRIu64 ". Time since last buffering ack in 100ns: %" PRIu64,
-          streamHandle, timeSinceLastBufferingAck);
+    DLOGD("Reported streamConnectionStale callback for stream handle %" PRIu64 ". Time since last buffering ack in 100ns: %" PRIu64, streamHandle,
+          timeSinceLastBufferingAck);
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     MUTEX_LOCK(pTest->mTestCallbackLock);
     pTest->mConnectionStaleFnCount++;
@@ -57,12 +54,9 @@ STATUS ProducerClientTestBase::testStreamConnectionStaleFunc(UINT64 customData,
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testDroppedFrameReportFunc(UINT64 customData,
-                                      STREAM_HANDLE streamHandle,
-                                      UINT64 frameTimecode)
+STATUS ProducerClientTestBase::testDroppedFrameReportFunc(UINT64 customData, STREAM_HANDLE streamHandle, UINT64 frameTimecode)
 {
-    DLOGD("Reported droppedFrame callback for stream handle %" PRIu64 ". Dropped frame timecode in 100ns: %" PRIu64,
-          streamHandle, frameTimecode);
+    DLOGD("Reported droppedFrame callback for stream handle %" PRIu64 ". Dropped frame timecode in 100ns: %" PRIu64, streamHandle, frameTimecode);
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     MUTEX_LOCK(pTest->mTestCallbackLock);
     pTest->mDroppedFrameFnCount++;
@@ -70,14 +64,11 @@ STATUS ProducerClientTestBase::testDroppedFrameReportFunc(UINT64 customData,
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testStreamErrorReportFunc(UINT64 customData,
-                                     STREAM_HANDLE streamHandle,
-                                     UPLOAD_HANDLE uploadHandle,
-                                     UINT64 fragmentTimecode,
-                                     STATUS errorStatus)
+STATUS ProducerClientTestBase::testStreamErrorReportFunc(UINT64 customData, STREAM_HANDLE streamHandle, UPLOAD_HANDLE uploadHandle,
+                                                         UINT64 fragmentTimecode, STATUS errorStatus)
 {
     DLOGD("Reported streamError callback for stream handle %" PRIu64 ". Upload handle %" PRIu64 ". Fragment timecode in"
-            " 100ns: %" PRIu64 ". Error status: 0x%08x\n",
+          " 100ns: %" PRIu64 ". Error status: 0x%08x\n",
           streamHandle, uploadHandle, fragmentTimecode, errorStatus);
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     BOOL resetStream = FALSE;
@@ -97,10 +88,8 @@ STATUS ProducerClientTestBase::testStreamErrorReportFunc(UINT64 customData,
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testFragmentAckReceivedFunc(UINT64 customData,
-                                       STREAM_HANDLE streamHandle,
-                                       UPLOAD_HANDLE uploadHandle,
-                                       PFragmentAck pFragmentAck)
+STATUS ProducerClientTestBase::testFragmentAckReceivedFunc(UINT64 customData, STREAM_HANDLE streamHandle, UPLOAD_HANDLE uploadHandle,
+                                                           PFragmentAck pFragmentAck)
 {
     UNUSED_PARAM(streamHandle);
     UNUSED_PARAM(uploadHandle);
@@ -135,11 +124,9 @@ STATUS ProducerClientTestBase::testFragmentAckReceivedFunc(UINT64 customData,
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testStreamReadyFunc(UINT64 customData,
-                               STREAM_HANDLE streamHandle)
+STATUS ProducerClientTestBase::testStreamReadyFunc(UINT64 customData, STREAM_HANDLE streamHandle)
 {
-    DLOGD("Reported streamReady callback for stream handle %" PRIu64,
-          streamHandle);
+    DLOGD("Reported streamReady callback for stream handle %" PRIu64, streamHandle);
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     MUTEX_LOCK(pTest->mTestCallbackLock);
     pTest->mStreamReadyFnCount++;
@@ -147,12 +134,9 @@ STATUS ProducerClientTestBase::testStreamReadyFunc(UINT64 customData,
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testStreamClosedFunc(UINT64 customData,
-                                STREAM_HANDLE streamHandle,
-                                UPLOAD_HANDLE uploadHandle)
+STATUS ProducerClientTestBase::testStreamClosedFunc(UINT64 customData, STREAM_HANDLE streamHandle, UPLOAD_HANDLE uploadHandle)
 {
-    DLOGD("Reported streamClosed callback for stream handle %" PRIu64 ". Upload handle %" PRIu64,
-          streamHandle, uploadHandle);
+    DLOGD("Reported streamClosed callback for stream handle %" PRIu64 ". Upload handle %" PRIu64, streamHandle, uploadHandle);
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     MUTEX_LOCK(pTest->mTestCallbackLock);
     pTest->mStreamClosedFnCount++;
@@ -163,8 +147,7 @@ STATUS ProducerClientTestBase::testStreamClosedFunc(UINT64 customData,
 
 STATUS ProducerClientTestBase::testStorageOverflowFunc(UINT64 customData, UINT64 remainingBytes)
 {
-    DLOGD("Reported storageOverflow callback. Remaining bytes %" PRIu64,
-          remainingBytes);
+    DLOGD("Reported storageOverflow callback. Remaining bytes %" PRIu64, remainingBytes);
 
     ProducerClientTestBase* pTest = (ProducerClientTestBase*) customData;
     MUTEX_LOCK(pTest->mTestCallbackLock);
@@ -175,61 +158,20 @@ STATUS ProducerClientTestBase::testStorageOverflowFunc(UINT64 customData, UINT64
     return STATUS_SUCCESS;
 }
 
-ProducerClientTestBase::ProducerClientTestBase() :
-        mClientHandle(INVALID_CLIENT_HANDLE_VALUE),
-        mCallbacksProvider(NULL),
-        mAccessKeyIdSet(FALSE),
-        mCaCertPath(NULL),
-        mProducerThread(INVALID_TID_VALUE),
-        mStartProducer(FALSE),
-        mAccessKey(NULL),
-        mSecretKey(NULL),
-        mSessionToken(NULL),
-        mRegion(NULL),
-        mFreeApiCallbacksFnCount(0),
-        mPutStreamFnCount(0),
-        mTagResourceFnCount(0),
-        mGetStreamingEndpointFnCount(0),
-        mDescribeStreamFnCount(0),
-        mDescribeStreamSecondFnCount(0),
-        mDescribeStreamThirdFnCount(0),
-        mDescribeStreamStopChainFnCount(0),
-        mCreateStreamFnCount(0),
-        mCreateDeviceFnCount(0),
-        mEasyPerformFnCount(0),
-        mWriteCallbackFnCount(0),
-        mReadCallbackFnCount(0),
-        mCurlGetDataEndpointCount(0),
-        mCurlPutMediaCount(0),
-        mCurlDescribeStreamCount(0),
-        mCurlCreateStreamCount(0),
-        mCurlTagResourceCount(0),
-        mCreateStreamStatus(STATUS_SUCCESS),
-        mCreateStreamCallResult(SERVICE_CALL_RESULT_OK),
-        mDescribeStreamStatus(STATUS_SUCCESS),
-        mDescribeStreamCallResult(SERVICE_CALL_RESULT_OK),
-        mGetEndpointStatus(STATUS_SUCCESS),
-        mGetEndpointCallResult(SERVICE_CALL_RESULT_OK),
-        mTagResourceStatus(STATUS_SUCCESS),
-        mTagResourceCallResult(SERVICE_CALL_RESULT_OK),
-        mPutMediaStatus(STATUS_SUCCESS),
-        mPutMediaCallResult(SERVICE_CALL_RESULT_OK),
-        mCurlEasyPerformInjectionCount(UINT32_MAX),
-        mWriteStatus(STATUS_SUCCESS),
-        mWriteBuffer(NULL),
-        mWriteDataSize(0),
-        mCurlWriteCallbackPassThrough(TRUE),
-        mReadStatus(STATUS_SUCCESS),
-        mReadSize(0),
-        mStreamCallbacks(NULL),
-        mProducerCallbacks(NULL),
-        mResetStreamCounter(0),
-        mAuthCallbacks(NULL),
-        mConnectionStaleFnCount(0),
-        mLastError(STATUS_SUCCESS),
-        mDescribeRetStatus(STATUS_SUCCESS),
-        mDescribeFailCount(0),
-        mDescribeRecoverCount(0)
+ProducerClientTestBase::ProducerClientTestBase()
+    : mClientHandle(INVALID_CLIENT_HANDLE_VALUE), mCallbacksProvider(NULL), mAccessKeyIdSet(FALSE), mCaCertPath(NULL),
+      mProducerThread(INVALID_TID_VALUE), mStartProducer(FALSE), mAccessKey(NULL), mSecretKey(NULL), mSessionToken(NULL), mRegion(NULL),
+      mFreeApiCallbacksFnCount(0), mPutStreamFnCount(0), mTagResourceFnCount(0), mGetStreamingEndpointFnCount(0), mDescribeStreamFnCount(0),
+      mDescribeStreamSecondFnCount(0), mDescribeStreamThirdFnCount(0), mDescribeStreamStopChainFnCount(0), mCreateStreamFnCount(0),
+      mCreateDeviceFnCount(0), mEasyPerformFnCount(0), mWriteCallbackFnCount(0), mReadCallbackFnCount(0), mCurlGetDataEndpointCount(0),
+      mCurlPutMediaCount(0), mCurlDescribeStreamCount(0), mCurlCreateStreamCount(0), mCurlTagResourceCount(0), mCreateStreamStatus(STATUS_SUCCESS),
+      mCreateStreamCallResult(SERVICE_CALL_RESULT_OK), mDescribeStreamStatus(STATUS_SUCCESS), mDescribeStreamCallResult(SERVICE_CALL_RESULT_OK),
+      mGetEndpointStatus(STATUS_SUCCESS), mGetEndpointCallResult(SERVICE_CALL_RESULT_OK), mTagResourceStatus(STATUS_SUCCESS),
+      mTagResourceCallResult(SERVICE_CALL_RESULT_OK), mPutMediaStatus(STATUS_SUCCESS), mPutMediaCallResult(SERVICE_CALL_RESULT_OK),
+      mCurlEasyPerformInjectionCount(UINT32_MAX), mWriteStatus(STATUS_SUCCESS), mWriteBuffer(NULL), mWriteDataSize(0),
+      mCurlWriteCallbackPassThrough(TRUE), mReadStatus(STATUS_SUCCESS), mReadSize(0), mStreamCallbacks(NULL), mProducerCallbacks(NULL),
+      mResetStreamCounter(0), mAuthCallbacks(NULL), mConnectionStaleFnCount(0), mLastError(STATUS_SUCCESS), mDescribeRetStatus(STATUS_SUCCESS),
+      mDescribeFailCount(0), mDescribeRecoverCount(0)
 {
     STATUS retStatus = STATUS_SUCCESS;
     auto logLevelStr = GETENV("AWS_KVS_LOG_LEVEL");
@@ -379,7 +321,7 @@ VOID ProducerClientTestBase::handlePressure(volatile BOOL* pressureFlag, UINT32 
     // first time pressure is detected
     if (*pressureFlag && mCurrentPressureState == BufferPressureOK) {
         mCurrentPressureState = BufferInPressure; // update state
-        *pressureFlag = FALSE;  // turn off pressure flag as it is handled
+        *pressureFlag = FALSE;                    // turn off pressure flag as it is handled
 
         // whether to give some extra time for the pressure to relieve. For example, storageOverflow takes longer
         // to recover as it needs to wait for persisted acks.
@@ -388,7 +330,7 @@ VOID ProducerClientTestBase::handlePressure(volatile BOOL* pressureFlag, UINT32 
             THREAD_SLEEP(gracePeriodSeconds * HUNDREDS_OF_NANOS_IN_A_SECOND);
         }
     } else if (mCurrentPressureState == BufferInPressure) { // if we are already in pressured state
-        if (*pressureFlag) { // still getting the pressure signal, remain in pressured state.
+        if (*pressureFlag) {                                // still getting the pressure signal, remain in pressured state.
             DLOGD("Pressure handler sleep for 1 second.");
             THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
             *pressureFlag = FALSE;
@@ -404,36 +346,25 @@ VOID ProducerClientTestBase::handlePressure(volatile BOOL* pressureFlag, UINT32 
     }
 }
 
-VOID ProducerClientTestBase::createDefaultProducerClient(BOOL cachingEndpoint, UINT64 createStreamTimeout, UINT64 stopStreamTimeout, BOOL continuousRetry, UINT64 rotationPeriod)
+VOID ProducerClientTestBase::createDefaultProducerClient(BOOL cachingEndpoint, UINT64 createStreamTimeout, UINT64 stopStreamTimeout,
+                                                         BOOL continuousRetry, UINT64 rotationPeriod)
 {
-    createDefaultProducerClient(cachingEndpoint ? API_CALL_CACHE_TYPE_ENDPOINT_ONLY : API_CALL_CACHE_TYPE_NONE,
-            createStreamTimeout,
-            stopStreamTimeout,
-            continuousRetry,
-            rotationPeriod);
+    createDefaultProducerClient(cachingEndpoint ? API_CALL_CACHE_TYPE_ENDPOINT_ONLY : API_CALL_CACHE_TYPE_NONE, createStreamTimeout,
+                                stopStreamTimeout, continuousRetry, rotationPeriod);
 }
 
-VOID ProducerClientTestBase::createDefaultProducerClient(API_CALL_CACHE_TYPE cacheType, UINT64 createStreamTimeout, UINT64 stopStreamTimeout, BOOL continuousRetry, UINT64 rotationPeriod)
+VOID ProducerClientTestBase::createDefaultProducerClient(API_CALL_CACHE_TYPE cacheType, UINT64 createStreamTimeout, UINT64 stopStreamTimeout,
+                                                         BOOL continuousRetry, UINT64 rotationPeriod)
 {
     PAuthCallbacks pAuthCallbacks;
     PStreamCallbacks pStreamCallbacks;
-    EXPECT_EQ(STATUS_SUCCESS, createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT,
-                                                                     cacheType,
-                                                                     TEST_CACHING_ENDPOINT_PERIOD,
-                                                                     mRegion,
-                                                                     TEST_CONTROL_PLANE_URI,
-                                                                     mCaCertPath,
-                                                                     NULL,
-                                                                     TEST_USER_AGENT,
-                                                                     &mCallbacksProvider));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAbstractDefaultCallbacksProvider(TEST_DEFAULT_CHAIN_COUNT, cacheType, TEST_CACHING_ENDPOINT_PERIOD, mRegion,
+                                                     TEST_CONTROL_PLANE_URI, mCaCertPath, NULL, TEST_USER_AGENT, &mCallbacksProvider));
 
-    EXPECT_EQ(STATUS_SUCCESS, createRotatingStaticAuthCallbacks(mCallbacksProvider,
-                                                                mAccessKey,
-                                                                mSecretKey,
-                                                                mSessionToken,
-                                                                rotationPeriod,
-                                                                mStreamingRotationPeriod,
-                                                                &pAuthCallbacks));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRotatingStaticAuthCallbacks(mCallbacksProvider, mAccessKey, mSecretKey, mSessionToken, rotationPeriod, mStreamingRotationPeriod,
+                                                &pAuthCallbacks));
 
     if (continuousRetry) {
         EXPECT_EQ(STATUS_SUCCESS, createContinuousRetryStreamCallbacks(mCallbacksProvider, &pStreamCallbacks));
@@ -560,9 +491,7 @@ VOID ProducerClientTestBase::freeStreams(BOOL sync)
 STATUS ProducerClientTestBase::curlEasyPerformHookFunc(PCurlResponse pCurlResponse)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    if (pCurlResponse == NULL ||
-        pCurlResponse->pCurlRequest == NULL ||
-        pCurlResponse->pCurlRequest->pCurlApiCallbacks == NULL) {
+    if (pCurlResponse == NULL || pCurlResponse->pCurlRequest == NULL || pCurlResponse->pCurlRequest->pCurlApiCallbacks == NULL) {
         return STATUS_NULL_ARG;
     }
 
@@ -636,14 +565,13 @@ STATUS ProducerClientTestBase::curlEasyPerformHookFunc(PCurlResponse pCurlRespon
     return retStatus;
 }
 
-STATUS ProducerClientTestBase::curlWriteCallbackHookFunc(PCurlResponse pCurlResponse, PCHAR pBuffer, UINT32 dataSize, PCHAR* ppRetBuffer, PUINT32 pRetDataSize)
+STATUS ProducerClientTestBase::curlWriteCallbackHookFunc(PCurlResponse pCurlResponse, PCHAR pBuffer, UINT32 dataSize, PCHAR* ppRetBuffer,
+                                                         PUINT32 pRetDataSize)
 {
     UNUSED_PARAM(pBuffer);
     UNUSED_PARAM(dataSize);
 
-    if (pCurlResponse == NULL ||
-        pCurlResponse->pCurlRequest == NULL ||
-        pCurlResponse->pCurlRequest->pCurlApiCallbacks == NULL) {
+    if (pCurlResponse == NULL || pCurlResponse->pCurlRequest == NULL || pCurlResponse->pCurlRequest->pCurlApiCallbacks == NULL) {
         return STATUS_NULL_ARG;
     }
 
@@ -662,21 +590,15 @@ STATUS ProducerClientTestBase::curlWriteCallbackHookFunc(PCurlResponse pCurlResp
     return pTest->mWriteStatus;
 }
 
-STATUS ProducerClientTestBase::curlReadCallbackHookFunc(PCurlResponse pCurlResponse,
-                                                        UPLOAD_HANDLE uploadHandle,
-                                                        PBYTE pBuffer,
-                                                        UINT32 bufferSize,
-                                                        PUINT32 pRetrievedSize,
-                                                        STATUS status)
+STATUS ProducerClientTestBase::curlReadCallbackHookFunc(PCurlResponse pCurlResponse, UPLOAD_HANDLE uploadHandle, PBYTE pBuffer, UINT32 bufferSize,
+                                                        PUINT32 pRetrievedSize, STATUS status)
 {
     UNUSED_PARAM(pBuffer);
     UNUSED_PARAM(bufferSize);
     UNUSED_PARAM(uploadHandle);
     UNUSED_PARAM(pRetrievedSize);
 
-    if (pCurlResponse == NULL ||
-        pCurlResponse->pCurlRequest == NULL ||
-        pCurlResponse->pCurlRequest->pCurlApiCallbacks == NULL) {
+    if (pCurlResponse == NULL || pCurlResponse->pCurlRequest == NULL || pCurlResponse->pCurlRequest->pCurlApiCallbacks == NULL) {
         return STATUS_NULL_ARG;
     }
 
@@ -705,9 +627,8 @@ STATUS ProducerClientTestBase::testFreeApiCallbackFunc(PUINT64 customData)
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testPutStreamFunc(UINT64 customData, PCHAR streamName, PCHAR containerType,
-                                                 UINT64 startTimestamp, BOOL absoluteFragmentTimestamp,
-                                                 BOOL acksEnabled, PCHAR streamingEndpoint,
+STATUS ProducerClientTestBase::testPutStreamFunc(UINT64 customData, PCHAR streamName, PCHAR containerType, UINT64 startTimestamp,
+                                                 BOOL absoluteFragmentTimestamp, BOOL acksEnabled, PCHAR streamingEndpoint,
                                                  PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamName);
@@ -725,8 +646,7 @@ STATUS ProducerClientTestBase::testPutStreamFunc(UINT64 customData, PCHAR stream
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testTagResourceFunc(UINT64 customData, PCHAR streamArn,
-                                                   UINT32 tagCount, PTag tags,
+STATUS ProducerClientTestBase::testTagResourceFunc(UINT64 customData, PCHAR streamArn, UINT32 tagCount, PTag tags,
                                                    PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamArn);
@@ -755,8 +675,7 @@ STATUS ProducerClientTestBase::testGetStreamingEndpointFunc(UINT64 customData, P
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testDescribeStreamFunc(UINT64 customData, PCHAR streamName,
-                                                      PServiceCallContext pServiceCallContext)
+STATUS ProducerClientTestBase::testDescribeStreamFunc(UINT64 customData, PCHAR streamName, PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamName);
     UNUSED_PARAM(pServiceCallContext);
@@ -765,8 +684,7 @@ STATUS ProducerClientTestBase::testDescribeStreamFunc(UINT64 customData, PCHAR s
     ProducerClientTestBase* pTestBase = (ProducerClientTestBase*) customData;
 
     // Fault injection
-    if (pTestBase->mDescribeStreamFnCount >= pTestBase->mDescribeFailCount &&
-            pTestBase->mDescribeStreamFnCount < pTestBase->mDescribeRecoverCount) {
+    if (pTestBase->mDescribeStreamFnCount >= pTestBase->mDescribeFailCount && pTestBase->mDescribeStreamFnCount < pTestBase->mDescribeRecoverCount) {
         retStatus = pTestBase->mDescribeRetStatus;
     }
 
@@ -775,8 +693,7 @@ STATUS ProducerClientTestBase::testDescribeStreamFunc(UINT64 customData, PCHAR s
     return retStatus;
 }
 
-STATUS ProducerClientTestBase::testDescribeStreamSecondFunc(UINT64 customData, PCHAR streamName,
-                                                      PServiceCallContext pServiceCallContext)
+STATUS ProducerClientTestBase::testDescribeStreamSecondFunc(UINT64 customData, PCHAR streamName, PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamName);
     UNUSED_PARAM(pServiceCallContext);
@@ -788,8 +705,7 @@ STATUS ProducerClientTestBase::testDescribeStreamSecondFunc(UINT64 customData, P
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testDescribeStreamThirdFunc(UINT64 customData, PCHAR streamName,
-                                                            PServiceCallContext pServiceCallContext)
+STATUS ProducerClientTestBase::testDescribeStreamThirdFunc(UINT64 customData, PCHAR streamName, PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamName);
     UNUSED_PARAM(pServiceCallContext);
@@ -801,8 +717,7 @@ STATUS ProducerClientTestBase::testDescribeStreamThirdFunc(UINT64 customData, PC
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testDescribeStreamStopChainFunc(UINT64 customData, PCHAR streamName,
-                                                      PServiceCallContext pServiceCallContext)
+STATUS ProducerClientTestBase::testDescribeStreamStopChainFunc(UINT64 customData, PCHAR streamName, PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamName);
     UNUSED_PARAM(pServiceCallContext);
@@ -814,9 +729,8 @@ STATUS ProducerClientTestBase::testDescribeStreamStopChainFunc(UINT64 customData
     return STATUS_STOP_CALLBACK_CHAIN;
 }
 
-STATUS ProducerClientTestBase::testCreateStreamFunc(UINT64 customData, PCHAR deviceName, PCHAR streamName,
-                                                    PCHAR contentType, PCHAR kmsKeyId, UINT64 retentionPeriod,
-                                                    PServiceCallContext pServiceCallContext)
+STATUS ProducerClientTestBase::testCreateStreamFunc(UINT64 customData, PCHAR deviceName, PCHAR streamName, PCHAR contentType, PCHAR kmsKeyId,
+                                                    UINT64 retentionPeriod, PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamName);
     UNUSED_PARAM(deviceName);
@@ -832,8 +746,7 @@ STATUS ProducerClientTestBase::testCreateStreamFunc(UINT64 customData, PCHAR dev
     return STATUS_SUCCESS;
 }
 
-STATUS ProducerClientTestBase::testCreateDeviceFunc(UINT64 customData, PCHAR deviceName,
-                                                    PServiceCallContext pServiceCallContext)
+STATUS ProducerClientTestBase::testCreateDeviceFunc(UINT64 customData, PCHAR deviceName, PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(deviceName);
     UNUSED_PARAM(pServiceCallContext);
@@ -847,16 +760,13 @@ STATUS ProducerClientTestBase::testCreateDeviceFunc(UINT64 customData, PCHAR dev
 
 VOID ProducerClientTestBase::printFrameInfo(PFrame pFrame)
 {
-    DLOGD("Putting frame. TID: 0x%016x, Id: %llu, Key Frame: %s, Size: %u, Dts: %llu, Pts: %llu",
-          GETTID(),
-          pFrame->index,
-          (((pFrame->flags & FRAME_FLAG_KEY_FRAME) == FRAME_FLAG_KEY_FRAME) ? "true" : "false"),
-          pFrame->size,
-          pFrame->decodingTs,
+    DLOGD("Putting frame. TID: 0x%016x, Id: %llu, Key Frame: %s, Size: %u, Dts: %llu, Pts: %llu", GETTID(), pFrame->index,
+          (((pFrame->flags & FRAME_FLAG_KEY_FRAME) == FRAME_FLAG_KEY_FRAME) ? "true" : "false"), pFrame->size, pFrame->decodingTs,
           pFrame->presentationTs);
 }
 
-STATUS ProducerClientTestBase::createRetryStrategyFn(PKvsRetryStrategy pKvsRetryStrategy) {
+STATUS ProducerClientTestBase::createRetryStrategyFn(PKvsRetryStrategy pKvsRetryStrategy)
+{
     STATUS retStatus = STATUS_SUCCESS;
     PExponentialBackoffRetryStrategyState pExponentialBackoffRetryStrategyState = NULL;
 
@@ -873,19 +783,22 @@ CleanUp:
     return retStatus;
 }
 
-STATUS ProducerClientTestBase::getCurrentRetryAttemptNumberFn(PKvsRetryStrategy pKvsRetryStrategy, PUINT32 pRetryCount) {
+STATUS ProducerClientTestBase::getCurrentRetryAttemptNumberFn(PKvsRetryStrategy pKvsRetryStrategy, PUINT32 pRetryCount)
+{
     return getExponentialBackoffRetryCount(pKvsRetryStrategy, pRetryCount);
 }
 
-STATUS ProducerClientTestBase::freeRetryStrategyFn(PKvsRetryStrategy pKvsRetryStrategy) {
+STATUS ProducerClientTestBase::freeRetryStrategyFn(PKvsRetryStrategy pKvsRetryStrategy)
+{
     return exponentialBackoffRetryStrategyFree(pKvsRetryStrategy);
 }
 
-STATUS ProducerClientTestBase::executeRetryStrategyFn(PKvsRetryStrategy pKvsRetryStrategy, PUINT64 retryWaitTime) {
+STATUS ProducerClientTestBase::executeRetryStrategyFn(PKvsRetryStrategy pKvsRetryStrategy, PUINT64 retryWaitTime)
+{
     return getExponentialBackoffRetryStrategyWaitTime(pKvsRetryStrategy, retryWaitTime);
 }
 
-}  // namespace video
-}  // namespace kinesis
-}  // namespace amazonaws
-}  // namespace com;
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/RotatingStaticAuthCallbacks.cpp
+++ b/tst/RotatingStaticAuthCallbacks.cpp
@@ -7,9 +7,8 @@
 /**
  * Creates Static Rotating Auth callbacks
  */
-STATUS createRotatingStaticAuthCallbacks(PClientCallbacks pCallbacksProvider, PCHAR accessKeyId, PCHAR secretKey,
-                                         PCHAR sessionToken, UINT64 expiration, UINT64 rotationPeriod,
-                                         PAuthCallbacks *ppStaticAuthCallbacks)
+STATUS createRotatingStaticAuthCallbacks(PClientCallbacks pCallbacksProvider, PCHAR accessKeyId, PCHAR secretKey, PCHAR sessionToken,
+                                         UINT64 expiration, UINT64 rotationPeriod, PAuthCallbacks* ppStaticAuthCallbacks)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -45,15 +44,14 @@ STATUS createRotatingStaticAuthCallbacks(PClientCallbacks pCallbacksProvider, PC
     pStaticAuthCallbacks->recoverCount = 0;
 
     // Create the credentials object
-    CHK_STATUS(createAwsCredentials(accessKeyId, 0, secretKey, 0, sessionToken, 0, expiration,
-                                    &pStaticAuthCallbacks->pAwsCredentials));
+    CHK_STATUS(createAwsCredentials(accessKeyId, 0, secretKey, 0, sessionToken, 0, expiration, &pStaticAuthCallbacks->pAwsCredentials));
 
     CHK_STATUS(addAuthCallbacks(pCallbacksProvider, (PAuthCallbacks) pStaticAuthCallbacks));
 
 CleanUp:
 
     if (STATUS_FAILED(retStatus)) {
-        freeRotatingStaticAuthCallbacks((PAuthCallbacks *) &pStaticAuthCallbacks);
+        freeRotatingStaticAuthCallbacks((PAuthCallbacks*) &pStaticAuthCallbacks);
         pStaticAuthCallbacks = NULL;
     }
 
@@ -71,7 +69,7 @@ CleanUp:
  *
  * NOTE: The caller should have passed a pointer which was previously created by the corresponding function
  */
-STATUS freeRotatingStaticAuthCallbacks(PAuthCallbacks *ppStaticAuthCallbacks)
+STATUS freeRotatingStaticAuthCallbacks(PAuthCallbacks* ppStaticAuthCallbacks)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -116,8 +114,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS getStreamingTokenEnvVarFunc(UINT64 customData, PCHAR streamName, STREAM_ACCESS_MODE accessMode,
-                                   PServiceCallContext pServiceCallContext)
+STATUS getStreamingTokenEnvVarFunc(UINT64 customData, PCHAR streamName, STREAM_ACCESS_MODE accessMode, PServiceCallContext pServiceCallContext)
 {
     UNUSED_PARAM(streamName);
     UNUSED_PARAM(accessMode);
@@ -144,11 +141,8 @@ STATUS getStreamingTokenEnvVarFunc(UINT64 customData, PCHAR streamName, STREAM_A
     // expiration is now time plus rotation period
     expirationTime = currentTime + pStaticAuthCallbacks->rotationPeriod;
 
-    retStatus = getStreamingTokenResultEvent(pServiceCallContext->customData,
-                                             SERVICE_CALL_RESULT_OK,
-                                             (PBYTE) pStaticAuthCallbacks->pAwsCredentials,
-                                             pStaticAuthCallbacks->pAwsCredentials->size,
-                                             expirationTime);
+    retStatus = getStreamingTokenResultEvent(pServiceCallContext->customData, SERVICE_CALL_RESULT_OK, (PBYTE) pStaticAuthCallbacks->pAwsCredentials,
+                                             pStaticAuthCallbacks->pAwsCredentials->size, expirationTime);
 
 CleanUp:
 
@@ -157,11 +151,7 @@ CleanUp:
 
         if (STATUS_FAILED(retStatus) && pServiceCallContext != NULL) {
             // Notify PIC on failure
-            getStreamingTokenResultEvent(pServiceCallContext->customData,
-                                         SERVICE_CALL_UNKNOWN,
-                                         NULL,
-                                         0,
-                                         0);
+            getStreamingTokenResultEvent(pServiceCallContext->customData, SERVICE_CALL_UNKNOWN, NULL, 0, 0);
 
             // Notify clients
             notifyCallResult(pCallbacksProvider, retStatus, pServiceCallContext->customData);
@@ -170,10 +160,9 @@ CleanUp:
 
     LEAVES();
     return retStatus;
-
 }
 
-STATUS getSecurityTokenEnvVarFunc(UINT64 customData, PBYTE *ppBuffer, PUINT32 pSize, PUINT64 pExpiration)
+STATUS getSecurityTokenEnvVarFunc(UINT64 customData, PBYTE* ppBuffer, PUINT32 pSize, PUINT64 pExpiration)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;

--- a/tst/main.cpp
+++ b/tst/main.cpp
@@ -13,17 +13,19 @@
 using namespace std;
 
 class Retrier : public ::testing::EmptyTestEventListener {
-    public:
-    string testFilter() {
+  public:
+    string testFilter()
+    {
         stringstream ss;
-        for (const string &testPath: failedTests) {
-          ss << ":" << testPath; 
+        for (const string& testPath : failedTests) {
+            ss << ":" << testPath;
         }
-        return ss.str(); 
+        return ss.str();
     }
 
-    protected:
-    virtual void OnTestEnd(const ::testing::TestInfo& info) {
+  protected:
+    virtual void OnTestEnd(const ::testing::TestInfo& info)
+    {
         // easy way to convert c string to c++ string
         string testCaseName = info.test_case_name();
         string name = info.name();
@@ -36,32 +38,32 @@ class Retrier : public ::testing::EmptyTestEventListener {
         }
     }
 
-    private:
+  private:
     unordered_set<string> failedTests;
 };
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
     int trial = 0, rc;
-    bool breakOnFailure; 
+    bool breakOnFailure;
 
     ::testing::InitGoogleTest(&argc, argv);
     breakOnFailure = ::testing::GTEST_FLAG(break_on_failure);
 
-    Retrier *retrier = new Retrier();
+    Retrier* retrier = new Retrier();
     // Adds a listener to the end. googletest takes the ownership.
-    ::testing::TestEventListeners& listeners = 
-        ::testing::UnitTest::GetInstance()->listeners();
+    ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
     listeners.Append(retrier);
 
     // Temporarily turn off the break_on_failure flag until the last trial. Otherwise, the retrier won't
     // be able to retry the failed tests since googletest will forcefully quit.
-    ::testing::GTEST_FLAG(break_on_failure) = false; 
+    ::testing::GTEST_FLAG(break_on_failure) = false;
 
     do {
         // Since this is the last trial, break_on_failure flag should be turned back on
         // if it was specified.
         if (trial >= MAX_TRIALS) {
-            ::testing::GTEST_FLAG(break_on_failure) = breakOnFailure;        
+            ::testing::GTEST_FLAG(break_on_failure) = breakOnFailure;
         }
         rc = RUN_ALL_TESTS();
 
@@ -69,7 +71,7 @@ int main(int argc, char **argv) {
         // If no test failed, the flag should be set to empty and RUN_ALL_TESTS should not be called
         // again since it should break out from the loop.
         ::testing::GTEST_FLAG(filter) = retrier->testFilter();
-    } while(rc != 0 && trial++ < MAX_TRIALS);
+    } while (rc != 0 && trial++ < MAX_TRIALS);
 
     return rc;
 }


### PR DESCRIPTION
*Issue #, if available:*
- #469

*What was changed?*
- The unit tests did not pass the clang-format check. Apply clang-format to the unit tests code.

*Why was it changed?*
- To have the code follow a consistent coding style.

*How was it changed?*
- Functionally, the code should not have any different behavior because it is all formatting.

*What testing was done for the changes?*
- The clang-format check now passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.