### PR TITLE
Downgrade to Ubuntu 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           ./tst/producer_test
 
   linux-gcc-code-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:
@@ -241,7 +241,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash)
 
   address-sanitizer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
@@ -271,7 +271,7 @@ jobs:
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   undefined-behavior-sanitizer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
@@ -356,7 +356,7 @@ jobs:
   #        timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   ubuntu-gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       AWS_KVS_LOG_LEVEL: 2
       CC: gcc
@@ -420,7 +420,7 @@ jobs:
           & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
 
   arm64-cross-compilation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -439,7 +439,7 @@ jobs:
           make
           file libcproducer.so
   linux-aarch64-cross-compilation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -458,7 +458,7 @@ jobs:
           make
           file libcproducer.so
   arm32-cross-compilation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CC: arm-linux-gnueabi-gcc
       CXX: arm-linux-gnueabi-g++
@@ -478,7 +478,7 @@ jobs:
           file libcproducer.so
 
   linux-build-gcc-static:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -489,7 +489,7 @@ jobs:
           make
 
   linux-thread-size-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Ubuntu version of the GitHub runners.

*Why was it changed?*
- Issues using the latest runner update (24)
- Failing to build PIC with Clang 18 with the same error mentioned in https://github.com/awslabs/amazon-kinesis-video-streams-pic/pull/272

*How was it changed?*
- Find and replaced ubuntu-latest with ubuntu-22.04

*What testing was done for the changes?*
- The CI will run for these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.