### PR TITLE
Add sample checks for Windows, Mac and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,36 +389,6 @@ jobs:
           ulimit -c unlimited -S
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
-  windows-msvc:
-    runs-on: windows-2022
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          choco install nasm strawberryperl pkgconfiglite
-      - name: Build repository
-        run: |
-          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
-          git config --system core.longpaths true
-          .github/build_windows.bat
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Run tests
-        run: |
-          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
-          & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
-
   arm64-cross-compilation:
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -1,0 +1,94 @@
+name: Producer C Samples on Mac and Linux
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  sample-checks:
+    name: ${{ matrix.runner.id }} - ${{ matrix.sample-executable }}
+    strategy:
+      matrix:
+        sample-executable:
+          - kvsAudioOnlyStreamingSample
+          - kvsAudioVideoStreamingSample
+          - kvsVideoOnlyOfflineStreamingSample
+          - kvsVideoOnlyRealtimeStreamingSample
+        runner:
+          - id: macos-latest
+            image: macos-latest
+
+          - id: ubuntu-22.04
+            image: ubuntu-latest
+            docker: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+
+          - id: ubuntu-20.04
+            image: ubuntu-latest
+            docker: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+
+      fail-fast: false
+
+    runs-on: ${{ matrix.runner.image }}
+    container: ${{ matrix.runner.docker || '' }}
+
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      KVS_DEBUG_DUMP_DATA_FILE_DIR: ./debug_output
+      DEBIAN_FRONTEND: noninteractive
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install mkvtoolnix
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          apt-get update
+          apt-get install -y git cmake build-essential pkg-config libssl-dev libcurl4-openssl-dev mkvtoolnix
+
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_DEPENDENCIES=OFF
+          make -j$(nproc)
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 900
+
+      - name: Run ${{ matrix.sample-executable }}
+        working-directory: ./build
+        run: |
+          mkdir -p $KVS_DEBUG_DUMP_DATA_FILE_DIR
+          ./${{ matrix.sample-executable }} demo-stream-producer-c-${{ matrix.runner.id }}-ci-${{ matrix.sample-executable }}
+
+      - name: Verify MKV dump
+        working-directory: ./build
+        run: |
+          if [ -z "$(ls -A $KVS_DEBUG_DUMP_DATA_FILE_DIR/*.mkv 2>/dev/null)" ]; then
+            echo "No MKV files found in $KVS_DEBUG_DUMP_DATA_FILE_DIR"
+            exit 1
+          fi
+
+          for file in $KVS_DEBUG_DUMP_DATA_FILE_DIR/*.mkv; do
+            echo "Verifying $file with mkvinfo (verbose and hexdump):"
+            mkvinfo -v -X "$file"
+          done

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,102 @@
+name: Producer C SDK Windows CI
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  unit-tests:
+    runs-on: windows-2022
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          choco install nasm strawberryperl pkgconfiglite
+      - name: Build repository
+        run: |
+          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
+          git config --system core.longpaths true
+          .github/build_windows.bat
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        run: |
+          $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
+          & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
+
+  VideoOnlyRealtimeStreamingSample:
+    runs-on: windows-2022
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      KVS_DEBUG_DUMP_DATA_FILE_DIR: D:\debug_output
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          choco install nasm strawberryperl pkgconfiglite mkvtoolnix
+          echo "PATH=$env:PATH;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin;C:\Program Files\MKVToolNix" >> $GITHUB_ENV
+      - name: Build repository
+        run: |
+          git config --system core.longpaths true
+          .github/build_windows.bat
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Run tests
+        working-directory: ./build
+        run: |
+          # Equivalent to set -x
+          Set-PSDebug -Trace 1
+
+          # Create the debug dump directory (equivalent to mkdir -p)
+          New-Item -ItemType Directory -Path $env:KVS_DEBUG_DUMP_DATA_FILE_DIR -Force
+          
+          $env:PATH += ";C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin;C:\Program Files\MKVToolNix"
+                    
+          # Equivalent to ls
+          dir
+
+          # Stream for 20s (default)
+          $exePath = Join-Path $PWD "kvsVideoOnlyRealtimeStreamingSample.exe"
+          & $exePath demo-stream
+
+      - name: Verify MKV dump
+        working-directory: ./build
+        run: |
+          $env:PATH += ";C:\Program Files\MKVToolNix"
+          $mkvFiles = Get-ChildItem -Path $env:KVS_DEBUG_DUMP_DATA_FILE_DIR -Filter *.mkv
+            if ($mkvFiles.Count -eq 0) {
+            Write-Error "No MKV files found in $env:KVS_DEBUG_DUMP_DATA_FILE_DIR"
+            exit 1
+          }
+      
+            # Run mkvinfo on each MKV file
+            foreach ($file in $mkvFiles) {
+            Write-Output "Verifying $($file.FullName) with mkvinfo:"
+            mkvinfo.exe "$($file.FullName)"
+          }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,8 +41,17 @@ jobs:
           $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\lib;D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\open-source\bin'
           & "D:\a\amazon-kinesis-video-streams-producer-c\amazon-kinesis-video-streams-producer-c\build\tst\producer_test.exe" --gtest_filter="-ProducerFunctionalityTest.pressure_on_buffer_duration_fail_new_connection_at_token_rotation"
 
-  VideoOnlyRealtimeStreamingSample:
+  sample-checks:
+    name: ${{ matrix.sample-executable }}
     runs-on: windows-2022
+    strategy:
+      matrix:
+        sample-executable:
+          - kvsAudioOnlyStreamingSample.exe
+          - kvsAudioVideoStreamingSample.exe
+          - kvsVideoOnlyOfflineStreamingSample.exe
+          - kvsVideoOnlyRealtimeStreamingSample.exe
+      fail-fast: false
     env:
       AWS_KVS_LOG_LEVEL: 2
       KVS_DEBUG_DUMP_DATA_FILE_DIR: D:\debug_output
@@ -67,7 +76,7 @@ jobs:
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 10800
-      - name: Run tests
+      - name: Run ${{ matrix.sample }}
         working-directory: ./build
         run: |
           # Equivalent to set -x
@@ -82,8 +91,8 @@ jobs:
           dir
 
           # Stream for 20s (default)
-          $exePath = Join-Path $PWD "kvsVideoOnlyRealtimeStreamingSample.exe"
-          & $exePath demo-stream
+          $exePath = Join-Path $PWD ${{ matrix.sample-executable }}
+          & $exePath demo-stream-producer-c-windows-ci-${{ matrix.sample-executable }}
 
       - name: Verify MKV dump
         working-directory: ./build
@@ -95,8 +104,8 @@ jobs:
             exit 1
           }
       
-            # Run mkvinfo on each MKV file
-            foreach ($file in $mkvFiles) {
-            Write-Output "Verifying $($file.FullName) with mkvinfo:"
-            mkvinfo.exe "$($file.FullName)"
+          # Run mkvinfo on each MKV file
+          foreach ($file in $mkvFiles) {
+            Write-Output "Verifying $($file.FullName) with mkvinfo (verbose and hexdump):"
+            mkvinfo.exe -v -X "$($file.FullName)"
           }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           $env:PATH += ";C:\Program Files\MKVToolNix"
           $mkvFiles = Get-ChildItem -Path $env:KVS_DEBUG_DUMP_DATA_FILE_DIR -Filter *.mkv
-            if ($mkvFiles.Count -eq 0) {
+          if ($mkvFiles.Count -eq 0) {
             Write-Error "No MKV files found in $env:KVS_DEBUG_DUMP_DATA_FILE_DIR"
             exit 1
           }

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           file-debug-logs
+	GIT_TAG           v1.2.0
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 # clone repo only
 ExternalProject_Add(libkvspic-download
 	GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-	GIT_TAG           v1.2.0
+	GIT_TAG           file-debug-logs
    	SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"
 	BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-build"
 	CMAKE_ARGS

--- a/samples/KvsAudioOnlyStreamingSample.c
+++ b/samples/KvsAudioOnlyStreamingSample.c
@@ -107,7 +107,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     MEMSET(&data, 0x00, SIZEOF(SampleCustomData));
 
-    STRCPY(audioCodec, AUDIO_CODEC_NAME_AAC); // aac audio by default
+    SNPRINTF(audioCodec, SIZEOF(audioCodec), "%s", AUDIO_CODEC_NAME_AAC); // aac audio by default
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     PCHAR pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreThingName;
@@ -132,7 +132,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 5) {
         if (!STRCMP(argv[2], AUDIO_CODEC_NAME_ALAW)) {
-            STRCPY(audioCodec, AUDIO_CODEC_NAME_ALAW);
+            SNPRINTF(audioCodec, SIZEOF(audioCodec), "%s", AUDIO_CODEC_NAME_ALAW);
         }
     }
 

--- a/samples/KvsAudioOnlyStreamingSample.c
+++ b/samples/KvsAudioOnlyStreamingSample.c
@@ -107,7 +107,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     MEMSET(&data, 0x00, SIZEOF(SampleCustomData));
 
-    STRNCPY(audioCodec, AUDIO_CODEC_NAME_AAC, STRLEN(AUDIO_CODEC_NAME_AAC)); // aac audio by default
+    STRCPY(audioCodec, AUDIO_CODEC_NAME_AAC); // aac audio by default
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     PCHAR pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreThingName;
@@ -132,7 +132,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 5) {
         if (!STRCMP(argv[2], AUDIO_CODEC_NAME_ALAW)) {
-            STRNCPY(audioCodec, AUDIO_CODEC_NAME_ALAW, STRLEN(AUDIO_CODEC_NAME_ALAW));
+            STRCPY(audioCodec, AUDIO_CODEC_NAME_ALAW);
         }
     }
 

--- a/samples/KvsAudioVideoStreamingSample.c
+++ b/samples/KvsAudioVideoStreamingSample.c
@@ -191,8 +191,8 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     MEMSET(&data, 0x00, SIZEOF(SampleCustomData));
 
-    STRNCPY(audioCodec, AUDIO_CODEC_NAME_AAC, STRLEN(AUDIO_CODEC_NAME_AAC));   // aac audio by default
-    STRNCPY(videoCodec, VIDEO_CODEC_NAME_H264, STRLEN(VIDEO_CODEC_NAME_H264)); // h264 video by default
+    STRCPY(audioCodec, AUDIO_CODEC_NAME_AAC);  // aac audio by default
+    STRCPY(videoCodec, VIDEO_CODEC_NAME_H264); // h264 video by default
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     PCHAR pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreThingName;
@@ -223,10 +223,10 @@ INT32 main(INT32 argc, CHAR* argv[])
     }
     if (argc >= 6) {
         if (!STRCMP(argv[4], AUDIO_CODEC_NAME_ALAW)) {
-            STRNCPY(audioCodec, AUDIO_CODEC_NAME_ALAW, STRLEN(AUDIO_CODEC_NAME_ALAW));
+            STRCPY(audioCodec, AUDIO_CODEC_NAME_ALAW);
         }
         if (!STRCMP(argv[5], VIDEO_CODEC_NAME_H265)) {
-            STRNCPY(videoCodec, VIDEO_CODEC_NAME_H265, STRLEN(VIDEO_CODEC_NAME_H265));
+            STRCPY(videoCodec, VIDEO_CODEC_NAME_H265);
             videoCodecID = VIDEO_CODEC_ID_H265;
         }
     }

--- a/samples/KvsAudioVideoStreamingSample.c
+++ b/samples/KvsAudioVideoStreamingSample.c
@@ -191,8 +191,8 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     MEMSET(&data, 0x00, SIZEOF(SampleCustomData));
 
-    STRCPY(audioCodec, AUDIO_CODEC_NAME_AAC);  // aac audio by default
-    STRCPY(videoCodec, VIDEO_CODEC_NAME_H264); // h264 video by default
+    SNPRINTF(audioCodec, SIZEOF(audioCodec), "%s", AUDIO_CODEC_NAME_AAC);  // aac audio by default
+    SNPRINTF(videoCodec, SIZEOF(videoCodec), "%s", VIDEO_CODEC_NAME_H264); // h264 video by default
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     PCHAR pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreThingName;
@@ -223,7 +223,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     }
     if (argc >= 6) {
         if (!STRCMP(argv[4], AUDIO_CODEC_NAME_ALAW)) {
-            STRCPY(audioCodec, AUDIO_CODEC_NAME_ALAW);
+            SNPRINTF(audioCodec, SIZEOF(audioCodec), "%s", AUDIO_CODEC_NAME_ALAW);
         }
         if (!STRCMP(argv[5], VIDEO_CODEC_NAME_H265)) {
             STRCPY(videoCodec, VIDEO_CODEC_NAME_H265);

--- a/samples/KvsVideoOnlyOfflineStreamingSample.c
+++ b/samples/KvsVideoOnlyOfflineStreamingSample.c
@@ -63,7 +63,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     BOOL firstFrame = TRUE;
     UINT64 startTime;
     CHAR videoCodec[VIDEO_CODEC_NAME_MAX_LENGTH];
-    STRNCPY(videoCodec, VIDEO_CODEC_NAME_H264, STRLEN(VIDEO_CODEC_NAME_H264)); // h264 video by default
+    STRCPY(videoCodec, VIDEO_CODEC_NAME_H264); // h264 video by default
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
@@ -109,7 +109,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 3) {
         if (!STRCMP(argv[2], VIDEO_CODEC_NAME_H265)) {
-            STRNCPY(videoCodec, VIDEO_CODEC_NAME_H265, STRLEN(VIDEO_CODEC_NAME_H265));
+            STRCPY(videoCodec, VIDEO_CODEC_NAME_H265);
             videoCodecID = VIDEO_CODEC_ID_H265;
         }
     }

--- a/samples/KvsVideoOnlyOfflineStreamingSample.c
+++ b/samples/KvsVideoOnlyOfflineStreamingSample.c
@@ -63,7 +63,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     BOOL firstFrame = TRUE;
     UINT64 startTime;
     CHAR videoCodec[VIDEO_CODEC_NAME_MAX_LENGTH];
-    STRCPY(videoCodec, VIDEO_CODEC_NAME_H264); // h264 video by default
+    SNPRINTF(videoCodec, SIZEOF(videoCodec), "%s", VIDEO_CODEC_NAME_H265); // h264 video by default
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
@@ -109,7 +109,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 3) {
         if (!STRCMP(argv[2], VIDEO_CODEC_NAME_H265)) {
-            STRCPY(videoCodec, VIDEO_CODEC_NAME_H265);
+            SNPRINTF(videoCodec, SIZEOF(videoCodec), "%s", VIDEO_CODEC_NAME_H265);
             videoCodecID = VIDEO_CODEC_ID_H265;
         }
     }

--- a/samples/KvsVideoOnlyRealtimeStreamingSample.c
+++ b/samples/KvsVideoOnlyRealtimeStreamingSample.c
@@ -69,7 +69,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     BOOL firstFrame = TRUE;
     UINT64 startTime;
     CHAR videoCodec[VIDEO_CODEC_NAME_MAX_LENGTH];
-    STRNCPY(videoCodec, VIDEO_CODEC_NAME_H264, STRLEN(VIDEO_CODEC_NAME_H264)); // h264 video by default
+    STRCPY(videoCodec, VIDEO_CODEC_NAME_H264); // h264 video by default
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
@@ -95,13 +95,6 @@ INT32 main(INT32 argc, CHAR* argv[])
     sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
 #endif
 
-    MEMSET(frameFilePath, 0x00, MAX_PATH_LEN + 1);
-    if (argc < 5) {
-        STRCPY(frameFilePath, (PCHAR) "../samples/");
-    } else {
-        STRNCPY(frameFilePath, argv[4], MAX_PATH_LEN);
-    }
-
     cacertPath = GETENV(CACERT_PATH_ENV_VAR);
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     streamName = pIotCoreThingName;
@@ -114,7 +107,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 3 && !IS_EMPTY_STRING(argv[2])) {
         if (!STRCMP(argv[2], VIDEO_CODEC_NAME_H265)) {
-            STRNCPY(videoCodec, VIDEO_CODEC_NAME_H265, STRLEN(VIDEO_CODEC_NAME_H265));
+            STRCPY(videoCodec, VIDEO_CODEC_NAME_H265);
             videoCodecID = VIDEO_CODEC_ID_H265;
         }
     }

--- a/samples/KvsVideoOnlyRealtimeStreamingSample.c
+++ b/samples/KvsVideoOnlyRealtimeStreamingSample.c
@@ -69,7 +69,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     BOOL firstFrame = TRUE;
     UINT64 startTime;
     CHAR videoCodec[VIDEO_CODEC_NAME_MAX_LENGTH];
-    STRCPY(videoCodec, VIDEO_CODEC_NAME_H264); // h264 video by default
+    SNPRINTF(videoCodec, SIZEOF(videoCodec), "%s", VIDEO_CODEC_NAME_H264); // h264 video by default
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
@@ -107,7 +107,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc >= 3 && !IS_EMPTY_STRING(argv[2])) {
         if (!STRCMP(argv[2], VIDEO_CODEC_NAME_H265)) {
-            STRCPY(videoCodec, VIDEO_CODEC_NAME_H265);
+            SNPRINTF(videoCodec, SIZEOF(videoCodec), "%s", VIDEO_CODEC_NAME_H265);
             videoCodecID = VIDEO_CODEC_ID_H265;
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
* N/A

*What was changed?*
- Adding verification for the samples on Windows with the mkv dump env flag
- Fix an issue where the codec string isn't properly null-terminated in the samples. Using strcpy, or const char* should be fine in this case because the arguments (constant values) are known ahead of time and not susceptible to user or network input.
- Remove an extra section with the file path (twice) in the KvsVideoOnlyRealtimeStreamingSample.c sample

*Why was it changed?*
- To verify portability of the sample applications and SDK options.

*How was it changed?*
- The CI will build the samples and run them

*What testing was done for the changes?*
- CI should be passing for these changes:

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/229912b3-f05f-473e-bb16-acc034def0a1" />
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/1223a5e0-6422-4725-8406-d8fb3d5760d0" />

And for Mac/Linux:
<img width="729" alt="image" src="https://github.com/user-attachments/assets/75422c32-9791-4ce2-bfc0-b73d56df4119" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.