### PR TITLE
CI: Downgrade CMake from 4.x back to 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           brew install pkgconfig
@@ -51,6 +55,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           brew install pkgconfig
@@ -80,6 +88,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           brew install pkgconfig
@@ -111,6 +123,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           brew install pkgconfig
@@ -145,6 +161,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           brew info openssl
@@ -176,6 +196,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           brew info openssl
@@ -204,6 +228,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -239,6 +267,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -269,6 +301,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -358,6 +394,10 @@ jobs:
         run: |
           sudo apt clean && sudo apt update
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -388,6 +428,10 @@ jobs:
           sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build Repository
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
@@ -407,6 +451,10 @@ jobs:
           sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build Repository
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
@@ -426,6 +474,10 @@ jobs:
           sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build Repository
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
@@ -439,6 +491,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build Repository
         run: |
           mkdir build && cd build
@@ -453,6 +509,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.x'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Install dependencies
         run: |
           choco install nasm strawberryperl pkgconfiglite
@@ -61,6 +65,10 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Install dependencies
         run: |
           choco install nasm strawberryperl pkgconfiglite mkvtoolnix


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/pull/478 is currently blocked by this

*What was changed?*
- GitHub actions recently (in progress of) upgraded CMake on their Ubuntu and Windows runners from v3 to v4. CMake v4 is not backwards compatible and breaks the builds, so downgrading. 
- https://github.com/actions/runner-images/issues/11926

```
[ 44%] No patch step for 'project_libcurl'
[ 55%] Performing configure step for 'project_libcurl'
CMake Error at CMakeLists.txt:41 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
gmake[2]: *** [CMakeFiles/project_libcurl.dir/build.make:92: build/src/project_libcurl-stamp/project_libcurl-configure] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/project_libcurl.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
CMake Error at CMake/Utilities.cmake:93 (message):
  CMake step for libcurl failed: 2
Call Stack (most recent call first):
  CMakeLists.txt:117 (build_dependency)


-- Configuring incomplete, errors occurred!
```

And, setting that flag doesn't fix the issue due to compile issues.

*Why was it changed?*
- libcurl and libwebsockets won't build on using CMake v4

*How was it changed?*
- Use the setup-cmake action as recommended by other users in the linked github actions issue.

*What testing was done for the changes?*
- This pull request is the test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.