### PR TITLE
Add Control Plane URI env var override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,16 +432,16 @@ if(BUILD_COMMON_CURL)
       FILES ${CMAKE_CURRENT_BINARY_DIR}/libcproducer.pc
       DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-    add_executable(kvsVideoOnlyRealtimeStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsVideoOnlyRealtimeStreamingSample.c)
+    add_executable(kvsVideoOnlyRealtimeStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsVideoOnlyRealtimeStreamingSample.c ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/Common.c)
     target_link_libraries(kvsVideoOnlyRealtimeStreamingSample cproducer)
 
-    add_executable(kvsVideoOnlyOfflineStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsVideoOnlyOfflineStreamingSample.c)
+    add_executable(kvsVideoOnlyOfflineStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsVideoOnlyOfflineStreamingSample.c ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/Common.c)
     target_link_libraries(kvsVideoOnlyOfflineStreamingSample cproducer)
 
-    add_executable(kvsAudioVideoStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsAudioVideoStreamingSample.c)
+    add_executable(kvsAudioVideoStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsAudioVideoStreamingSample.c ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/Common.c)
     target_link_libraries(kvsAudioVideoStreamingSample cproducer)
 
-    add_executable(kvsAudioOnlyStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsAudioOnlyStreamingSample.c)
+    add_executable(kvsAudioOnlyStreamingSample ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/KvsAudioOnlyStreamingSample.c ${KINESIS_VIDEO_PRODUCER_C_SRC}/samples/Common.c)
     target_link_libraries(kvsAudioOnlyStreamingSample cproducer)
 
     if (BUILD_TEST)

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -1,0 +1,18 @@
+#include "Samples.h"
+
+VOID getEndpointOverride(PCHAR outUrl, SIZE_T maxLen)
+{
+    const char* envValue = GETENV(CONTROL_PLANE_URI_ENV_VAR);
+
+    if (IS_NULL_OR_EMPTY_STRING(envValue)) {
+        outUrl[0] = '\0';
+        return;
+    }
+
+    if (STRNCMP(envValue, "https://", 8) != 0) {
+        SNPRINTF(outUrl, maxLen, "https://%s", envValue);
+        return;
+    }
+
+    SNPRINTF(outUrl, maxLen, "%s", envValue);
+}

--- a/samples/KvsAudioOnlyStreamingSample.c
+++ b/samples/KvsAudioOnlyStreamingSample.c
@@ -224,7 +224,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     CHK_STATUS(createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey,
                                                                                    cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
-                                                                                   NULL, GETENV(CONTROL_PLANE_URI_ENV_VAR), &pClientCallbacks));
+                                                                                   NULL, endpointOverride, &pClientCallbacks));
 #else
     CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
                                                                                    NULL, NULL, endpointOverride, &pClientCallbacks));

--- a/samples/KvsAudioOnlyStreamingSample.c
+++ b/samples/KvsAudioOnlyStreamingSample.c
@@ -104,6 +104,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     CHAR audioCodec[AUDIO_CODEC_NAME_MAX_LENGTH];
     BYTE aacAudioCpd[KVS_AAC_CPD_SIZE_BYTE];
     BYTE alawAudioCpd[KVS_PCM_CPD_SIZE_BYTE];
+    CHAR endpointOverride[MAX_URI_CHAR_LEN];
 
     MEMSET(&data, 0x00, SIZEOF(SampleCustomData));
 
@@ -219,12 +220,14 @@ INT32 main(INT32 argc, CHAR* argv[])
     data.startTime = GETTIME();
     data.firstFrame = TRUE;
 
+    getEndpointOverride(endpointOverride, SIZEOF(endpointOverride));
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificate(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, cacertPath,
-                                                                pIotCoreRoleAlias, pIotCoreThingName, region, NULL, NULL, &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey,
+                                                                                   cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
+                                                                                   NULL, GETENV(CONTROL_PLANE_URI_ENV_VAR), &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentials(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath, NULL, NULL,
-                                                                &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
+                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/KvsAudioVideoStreamingSample.c
+++ b/samples/KvsAudioVideoStreamingSample.c
@@ -188,6 +188,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     BYTE aacAudioCpd[KVS_AAC_CPD_SIZE_BYTE];
     BYTE alawAudioCpd[KVS_PCM_CPD_SIZE_BYTE];
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
+    CHAR endpointOverride[MAX_URI_CHAR_LEN];
 
     MEMSET(&data, 0x00, SIZEOF(SampleCustomData));
 
@@ -324,12 +325,15 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     data.startTime = GETTIME();
     data.firstFrame = TRUE;
+
+    getEndpointOverride(endpointOverride, SIZEOF(endpointOverride));
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificate(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, cacertPath,
-                                                                pIotCoreRoleAlias, pIotCoreThingName, region, NULL, NULL, &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey,
+                                                                                   cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
+                                                                                   NULL, endpointOverride, &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentials(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath, NULL, NULL,
-                                                                &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
+                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/KvsVideoOnlyOfflineStreamingSample.c
+++ b/samples/KvsVideoOnlyOfflineStreamingSample.c
@@ -65,6 +65,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     CHAR videoCodec[VIDEO_CODEC_NAME_MAX_LENGTH];
     SNPRINTF(videoCodec, SIZEOF(videoCodec), "%s", VIDEO_CODEC_NAME_H265); // h264 video by default
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
+    CHAR endpointOverride[MAX_URI_CHAR_LEN];
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     PCHAR pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreThingName;
@@ -135,12 +136,14 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     startTime = GETTIME();
 
+    getEndpointOverride(endpointOverride, SIZEOF(endpointOverride));
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificate(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, cacertPath,
-                                                                pIotCoreRoleAlias, pIotCoreThingName, region, NULL, NULL, &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey,
+                                                                                   cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
+                                                                                   NULL, endpointOverride, &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentials(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath, NULL, NULL,
-                                                                &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
+                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/KvsVideoOnlyRealtimeStreamingSample.c
+++ b/samples/KvsVideoOnlyRealtimeStreamingSample.c
@@ -71,6 +71,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     CHAR videoCodec[VIDEO_CODEC_NAME_MAX_LENGTH];
     SNPRINTF(videoCodec, SIZEOF(videoCodec), "%s", VIDEO_CODEC_NAME_H264); // h264 video by default
     VIDEO_CODEC_ID videoCodecID = VIDEO_CODEC_ID_H264;
+    CHAR endpointOverride[MAX_URI_CHAR_LEN];
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     PCHAR pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreThingName;
@@ -146,12 +147,14 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     startTime = GETTIME();
 
+    getEndpointOverride(endpointOverride, SIZEOF(endpointOverride));
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificate(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey, cacertPath,
-                                                                pIotCoreRoleAlias, pIotCoreThingName, region, NULL, NULL, &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(pIotCoreCredentialEndpoint, pIotCoreCert, pIotCorePrivateKey,
+                                                                                   cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
+                                                                                   NULL, endpointOverride, &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentials(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath, NULL, NULL,
-                                                                &pClientCallbacks));
+    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
+                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -19,8 +19,12 @@ extern "C" {
 #define IOT_CORE_THING_NAME          ((PCHAR) "AWS_IOT_CORE_THING_NAME")
 #define IOT_CORE_CERTIFICATE_ID      ((PCHAR) "AWS_IOT_CORE_CERTIFICATE_ID")
 
+#define CONTROL_PLANE_URI_ENV_VAR ((PCHAR) "CONTROL_PLANE_URI")
+
 #define FILE_LOGGING_BUFFER_SIZE (100 * 1024)
 #define MAX_NUMBER_OF_LOG_FILES  5
+
+VOID getEndpointOverride(PCHAR, SIZE_T);
 
 #ifdef __cplusplus
 }

--- a/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
@@ -322,6 +322,28 @@ typedef enum {
 PUBLIC_API STATUS createDefaultCallbacksProviderWithAwsCredentials(PCHAR, PCHAR, PCHAR, UINT64, PCHAR, PCHAR, PCHAR, PCHAR, PClientCallbacks*);
 
 /**
+ * Creates a default callbacks provider based on static AWS credentials
+ *
+ * NOTE: The caller is responsible for releasing the structure by calling
+ * the corresponding {@link freeCallbackProvider} API.
+ *
+ * @param[in] PCHAR Access Key Id
+ * @param[in] PCHAR Secret Key
+ * @param[in,opt] PCHAR Session Token
+ * @param[in] UINT64 Expiration of the token. MAX_UINT64 if non-expiring
+ * @param[in,opt] PCHAR AWS region
+ * @param[in,opt] PCHAR CA Cert Path
+ * @param[in,opt] PCHAR User agent name (Use NULL)
+ * @param[in,out] PCHAR Custom user agent to be used in the API calls
+ * @param[in,opt] PCHAR Control Plane endpoint override
+ * @param[out] PClientCallbacks* Returned pointer to callbacks provider
+ *
+ * @return STATUS code of the execution
+ */
+PUBLIC_API STATUS createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(PCHAR, PCHAR, PCHAR, UINT64, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR,
+                                                                                      PClientCallbacks*);
+
+/**
  * Creates a default callbacks provider that uses iot certificate as auth method.
  *
  * NOTE: The caller is responsible for releasing the structure by calling
@@ -341,6 +363,29 @@ PUBLIC_API STATUS createDefaultCallbacksProviderWithAwsCredentials(PCHAR, PCHAR,
  * @return STATUS code of the execution
  */
 PUBLIC_API STATUS createDefaultCallbacksProviderWithIotCertificate(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PClientCallbacks*);
+
+/**
+ * Creates a default callbacks provider that uses iot certificate as auth method.
+ *
+ * NOTE: The caller is responsible for releasing the structure by calling
+ * the corresponding {@link freeCallbackProvider} API.
+ *
+ * @param[in] PCHAR IoT endpoint to use for the auth
+ * @param[in] PCHAR Credential cert path
+ * @param[in] PCHAR Private key path
+ * @param[in,opt] PCHAR CA Cert path
+ * @param[in] PCHAR Role alias name
+ * @param[in] PCHAR IoT Thing name
+ * @param[in,opt] PCHAR AWS region
+ * @param[in,opt] PCHAR User agent name (Use NULL)
+ * @param[in,opt] PCHAR Custom user agent to be used in the API calls
+ * @param[in,opt] PCHAR Control Plane endpoint override
+ * @param[out] PClientCallbacks* Returned pointer to callbacks provider
+ *
+ * @return STATUS code of the execution
+ */
+PUBLIC_API STATUS createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PCHAR,
+                                                                                      PCHAR, PClientCallbacks* ppClientCallbacks);
 
 /**
  * Creates a default callbacks provider that uses iot certificate as auth method.

--- a/src/source/CallbacksProvider.c
+++ b/src/source/CallbacksProvider.c
@@ -68,13 +68,30 @@ STATUS createDefaultCallbacksProviderWithAwsCredentials(PCHAR accessKeyId, PCHAR
                                                         PClientCallbacks* ppClientCallbacks)
 {
     ENTERS();
+
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(
+        accessKeyId, secretKey, sessionToken, expiration, region, caCertPath, userAgentPostfix, customUserAgent, EMPTY_STRING, ppClientCallbacks));
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(PCHAR accessKeyId, PCHAR secretKey, PCHAR sessionToken, UINT64 expiration,
+                                                                           PCHAR region, PCHAR caCertPath, PCHAR userAgentPostfix,
+                                                                           PCHAR customUserAgent, char* endpointOverride,
+                                                                           PClientCallbacks* ppClientCallbacks)
+{
+    ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PCallbacksProvider pCallbacksProvider = NULL;
     PAuthCallbacks pAuthCallbacks = NULL;
     PStreamCallbacks pStreamCallbacks = NULL;
 
     CHK_STATUS(createAbstractDefaultCallbacksProvider(DEFAULT_CALLBACK_CHAIN_COUNT, API_CALL_CACHE_TYPE_ALL, ENDPOINT_UPDATE_PERIOD_SENTINEL_VALUE,
-                                                      region, EMPTY_STRING, caCertPath, userAgentPostfix, customUserAgent, ppClientCallbacks));
+                                                      region, endpointOverride, caCertPath, userAgentPostfix, customUserAgent, ppClientCallbacks));
 
     pCallbacksProvider = (PCallbacksProvider) *ppClientCallbacks;
 
@@ -109,9 +126,27 @@ CleanUp:
     return retStatus;
 }
 
-STATUS createDefaultCallbacksProviderWithIotCertificate(PCHAR endpoint, PCHAR iotCertPath, PCHAR privateKeyPath, PCHAR caCertPath, PCHAR roleAlias,
-                                                        PCHAR streamName, PCHAR region, PCHAR userAgentPostfix, PCHAR customUserAgent,
-                                                        PClientCallbacks* ppClientCallbacks)
+STATUS createDefaultCallbacksProviderWithIotCertificate(PCHAR iotDataPlaneEndpoint, PCHAR iotCertPath, PCHAR privateKeyPath, PCHAR caCertPath,
+                                                        PCHAR roleAlias, PCHAR streamName, PCHAR region, PCHAR userAgentPostfix,
+                                                        PCHAR customUserAgent, PClientCallbacks* ppClientCallbacks)
+{
+    ENTERS();
+
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK_STATUS(createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(iotDataPlaneEndpoint, iotCertPath, privateKeyPath, caCertPath,
+                                                                                   roleAlias, streamName, region, userAgentPostfix, customUserAgent,
+                                                                                   EMPTY_STRING, ppClientCallbacks));
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride(PCHAR endpoint, PCHAR iotCertPath, PCHAR privateKeyPath, PCHAR caCertPath,
+                                                                           PCHAR roleAlias, PCHAR streamName, PCHAR region, PCHAR userAgentPostfix,
+                                                                           PCHAR customUserAgent, PCHAR kvsControlPlaneEndpointOverride,
+                                                                           PClientCallbacks* ppClientCallbacks)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -120,7 +155,8 @@ STATUS createDefaultCallbacksProviderWithIotCertificate(PCHAR endpoint, PCHAR io
     PStreamCallbacks pStreamCallbacks = NULL;
 
     CHK_STATUS(createAbstractDefaultCallbacksProvider(DEFAULT_CALLBACK_CHAIN_COUNT, API_CALL_CACHE_TYPE_ALL, ENDPOINT_UPDATE_PERIOD_SENTINEL_VALUE,
-                                                      region, EMPTY_STRING, caCertPath, userAgentPostfix, customUserAgent, ppClientCallbacks));
+                                                      region, kvsControlPlaneEndpointOverride, caCertPath, userAgentPostfix, customUserAgent,
+                                                      ppClientCallbacks));
 
     pCallbacksProvider = (PCallbacksProvider) *ppClientCallbacks;
 


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Updated all sample applications to support an optional override of the Kinesis Video Streams control plane endpoint via a new environment variable CONTROL_PLANE_URI.

*Why was it changed?*
- Make it easier for developers to redirect control plane requests to a different endpoint without needing to modify the code.
 
*How was it changed?*
- Introduced CONTROL_PLANE_URI_ENV_VAR in `Samples.h`
- Added two new APIs:
  - `createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride`
  - `createDefaultCallbacksProviderWithIotCertificateAndEndpointOverride`
- These allow specifying an endpoint override while preserving the original logic
- Modified all sample applications to prefer the new APIs, falling back to the default endpoint if the environment variable is not set.
- Internally, refactored the legacy APIs to call the new implementations with an empty string as the default endpoint override, preserving backward compatibility.
- To make it developer-friendly, when running with IoT (since you need to pass 2 endpoints), check if the URI is missing `https://`, and if so, add it.

*What testing was done for the changes?*
- Ran the sample with and without the endpoint override environment variable set (with `https://` and without), both with IoT credentials and AWS credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.