### PR TITLE
Add RPATH so libcurl can find libssl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           echo "CMAKE_FLAGS_EXTRA=-DBUILD_DEPENDENCIES=OFF" >> $GITHUB_ENV
 
       - name: Build repository
+        if: ${{ !(matrix.compiler.name == 'gcc-14' && matrix.openssl == 'deps-off') }}
         run: |
           $CC --version
           $CXX --version
@@ -76,6 +77,7 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ !(matrix.compiler.name == 'gcc-14' && matrix.openssl == 'deps-off') }}
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
@@ -83,6 +85,7 @@ jobs:
           role-duration-seconds: 3600
 
       - name: Run tests
+        if: ${{ !(matrix.compiler.name == 'gcc-14' && matrix.openssl == 'deps-off') }}
         working-directory: ./build
         run: |
           ./tst/producer_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,198 +10,69 @@ on:
       - develop
       - master
 jobs:
-  mac-os-build-gcc:
-    runs-on: macos-13
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: gcc-14
-      CXX: g++-14
-      AWS_KVS_LOG_LEVEL: 2
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.x'
-      - name: Build repository
-        run: |
-          brew install pkgconfig
-          mkdir build && cd build
-          cmake .. --trace -DBUILD_TEST=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 3600
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+  mac-os-builds:
+    strategy:
+      matrix:
+        compiler:
+          - name: Clang-15
+            cc: clang
+            cxx: clang++
+          - name: gcc-14
+            cc: gcc-14
+            cxx: g++-14
+        cpu:
+          - name: Intel
+            image: macos-13
+          - name: Apple Silicon
+            image: macos-15
+        openssl:
+          - specific-preinstalled
+          - from-source
+          - deps-off
+      fail-fast: false
 
-  mac-os-build-clang:
-    runs-on: macos-13
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.x'
-      - name: Build repository
-        run: |
-          brew install pkgconfig
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 3600
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+    name: ${{ matrix.cpu.name }} Mac-${{ matrix.compiler.name }}-${{ matrix.openssl }}
+    runs-on: ${{ matrix.cpu.image }}
 
-  mac-os-m1-build-clang:
-    runs-on: macos-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.x'
-      - name: Build repository
-        run: |
-          brew install pkgconfig
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 3600
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CC: ${{ matrix.compiler.cc }}
+      CXX: ${{ matrix.compiler.cxx }}
 
-  mac-os-m1-build-gcc:
-    runs-on: macos-latest
-    env:
-      CC: gcc-13
-      CXX: g++-13
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.x'
-      - name: Build repository
-        run: |
-          brew install pkgconfig
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 3600
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
+        uses: actions/checkout@v4
 
-  mac-os-build-gcc-local-openssl:
-    runs-on: macos-13
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      CC: gcc-14
-      CXX: g++-14
-      AWS_KVS_LOG_LEVEL: 2
-      LDFLAGS: -L/usr/local/opt/openssl@3/lib
-      CPPFLAGS: -I/usr/local/opt/openssl@3/include
-      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
-      - name: Build repository
-        run: |
-          brew info openssl
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DLOCAL_OPENSSL_BUILD=ON
-          make
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 3600
-      - name: Run tests
-        run: |
-          cd build
-          ./tst/producer_test
 
-  mac-os-build-clang-local-openssl:
-    runs-on: macos-13
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-      LDFLAGS: -L/usr/local/opt/openssl@3/lib
-      CPPFLAGS: -I/usr/local/opt/openssl@3/include
-      OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '3.x'
+      - name: Setup envs for including OpenSSL locally
+        if: ${{ matrix.openssl == 'specific-preinstalled' }}
+        run: |
+          OPENSSL_PATH=$(brew --prefix openssl@3)
+          echo "LDFLAGS=-L$OPENSSL_PATH/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I$OPENSSL_PATH/include" >> $GITHUB_ENV
+          echo "OPENSSL_ROOT_DIR=$OPENSSL_PATH" >> $GITHUB_ENV
+          echo "CMAKE_FLAGS_EXTRA=-DLOCAL_OPENSSL_BUILD=ON" >> $GITHUB_ENV
+
+      - name: Set CMake flags for Dependencies=OFF
+        if: ${{ matrix.openssl == 'deps-off' }}
+        run: |
+          echo "CMAKE_FLAGS_EXTRA=-DBUILD_DEPENDENCIES=OFF" >> $GITHUB_ENV
+
       - name: Build repository
         run: |
-          brew info openssl
+          $CC --version
+          $CXX --version
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE -DLOCAL_OPENSSL_BUILD=ON
-          make
+          cmake .. -DBUILD_TEST=ON $CMAKE_FLAGS_EXTRA
+          make -j
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -209,9 +80,10 @@ jobs:
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 3600
+
       - name: Run tests
+        working-directory: ./build
         run: |
-          cd build
           ./tst/producer_test
 
   linux-gcc-code-coverage:
@@ -375,41 +247,87 @@ jobs:
   #        timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   ubuntu-gcc:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        container:
+          - name: Ubuntu 20.04
+            image: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+          - name: Ubuntu 22.04
+            image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+          - name: Ubuntu 24.04
+            image: public.ecr.aws/ubuntu/ubuntu:24.04_stable
+        build-configuration:
+          - name: curl
+            cmake-args: "-DBUILD_COMMON_CURL=ON -DBUILD_COMMON_LWS=OFF"
+          - name: lws
+            cmake-args: "-DBUILD_COMMON_CURL=OFF -DBUILD_COMMON_LWS=ON"
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container.image }}
+
+    name: ${{ matrix.container.name }}-gcc-${{ matrix.build-configuration.name }}
+
     env:
+      DEBIAN_FRONTEND: noninteractive
       AWS_KVS_LOG_LEVEL: 2
       CC: gcc
       CXX: g++
+
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Install dependencies
         run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          apt-get update
+          apt-get install -y git cmake build-essential pkg-config
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE
-          make
+          cmake .. -DBUILD_TEST=ON ${{ matrix.build-configuration.cmake-args }}
+          make -j
+
+      - name: Check libCurl
+        if: ${{ matrix.build-configuration.name == 'curl' }}
+        working-directory: ./open-source/lib
+        run: |
+          set -x
+          readelf -d libcurl.so | grep -i "runpath"
+          ldd libcurl.so
+          echo "Checking ldd output for missing dependencies..."
+          if ldd libcurl.so | grep "not found"; then
+            echo "❌ Missing dependencies detected in libcurl.so"
+            exit 1
+          else
+            echo "✅ All dependencies are found"
+          fi
+
       - name: Configure AWS Credentials
+        # Producer-C only has CURL implementation
+        if: ${{ matrix.build-configuration.name == 'curl' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 3600
+
       - name: Run tests
+        # Producer-C only has CURL implementation
+        if: ${{ matrix.build-configuration.name == 'curl' }}
+        working-directory: ./build
         run: |
-          cd build
-          ulimit -c unlimited -S
           timeout --signal=SIGABRT 150m ./tst/producer_test --gtest_break_on_failure
 
   arm64-cross-compilation:
@@ -433,8 +351,9 @@ jobs:
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64
-          make
+          make -j
           file libcproducer.so
+
   linux-aarch64-cross-compilation:
     runs-on: ubuntu-22.04
     env:
@@ -456,8 +375,9 @@ jobs:
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64
-          make
+          make -j
           file libcproducer.so
+
   arm32-cross-compilation:
     runs-on: ubuntu-22.04
     env:
@@ -468,12 +388,15 @@ jobs:
         run: |
           sudo apt clean && sudo apt update
           sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
+
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Build Repository
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
@@ -498,17 +421,30 @@ jobs:
           make
 
   linux-thread-size-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
     permissions:
       id-token: write
       contents: read
+
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git cmake build-essential pkg-config
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -516,11 +452,13 @@ jobs:
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-duration-seconds: 3600
+
       - name: Build Repository
         run: |
           mkdir build && cd build
           cmake .. -DBUILD_TEST=TRUE -DKVS_DEFAULT_STACK_SIZE=65536
           make -j$(nproc)
+
       - name: Run tests with expected failure
         run: |
           set +e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - name: Clang-15
+          - name: Clang
             cc: clang
             cxx: clang++
           - name: gcc-14
@@ -63,6 +63,7 @@ jobs:
       - name: Set CMake flags for Dependencies=OFF
         if: ${{ matrix.openssl == 'deps-off' }}
         run: |
+          brew install googletest
           echo "CMAKE_FLAGS_EXTRA=-DBUILD_DEPENDENCIES=OFF" >> $GITHUB_ENV
 
       - name: Build repository

--- a/CMake/Dependencies/libcurl-CMakeLists.txt
+++ b/CMake/Dependencies/libcurl-CMakeLists.txt
@@ -33,16 +33,25 @@ endif()
 # Tell Curl to find all its deps (OpenSSL/MbedTLS) in open-source directory
 # (except when using pre-installed)
 if (NOT OPENSSL_ROOT_DIR)
-    set(CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_PREFIX_PATH=${OPEN_SRC_INSTALL_PREFIX})
+    set(CMAKE_ARGS
+        ${CMAKE_ARGS}
+        -DCMAKE_PREFIX_PATH=${OPEN_SRC_INSTALL_PREFIX}
+        -DCMAKE_INSTALL_RPATH=$ORIGIN
+    )
+else()
+    set(CMAKE_ARGS
+        ${CMAKE_ARGS}
+        -DCMAKE_INSTALL_RPATH=${OPENSSL_ROOT_DIR}/lib:$ORIGIN
+    )
 endif()
 
 if (WIN32)
-    set(CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_USE_WINSSL=1 -DCURL_STATIC_CRT=1)
+    set(CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_USE_SCHANNEL=1 -DCURL_STATIC_CRT=1)
 endif()
 
 ExternalProject_Add(project_libcurl
     GIT_REPOSITORY    https://github.com/curl/curl.git
-    GIT_TAG           curl-7_71_1
+    GIT_TAG           curl-7_74_0
     GIT_SHALLOW       TRUE
     GIT_PROGRESS      TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build

--- a/tst/ProducerFunctionalityTest.cpp
+++ b/tst/ProducerFunctionalityTest.cpp
@@ -688,7 +688,7 @@ TEST_F(ProducerFunctionalityTest, intermittent_producer_verify_eofr_sent)
     UPLOAD_HANDLE streamUploadHandle = 0;
 
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
-    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION));
+    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_OFFLINE, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION));
     streamHandle = mStreams[0];
 
     for (i = 0; i < totalFrames; i++) {
@@ -743,7 +743,7 @@ TEST_F(ProducerFunctionalityTest, intermittent_producer_verify_eofr_sent_multi_t
 
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
-    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION));
+    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_OFFLINE, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION));
     streamHandle = mStreams[0];
 
     mFrame.flags = FRAME_FLAG_KEY_FRAME;
@@ -1552,7 +1552,7 @@ TEST_F(ProducerFunctionalityTest, curl_timeout_idling_force_ack)
 
     createDefaultProducerClient(FALSE, FUNCTIONALITY_TEST_CREATE_STREAM_TIMEOUT);
 
-    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION));
+    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_OFFLINE, TEST_MAX_STREAM_LATENCY, TEST_STREAM_BUFFER_DURATION));
     streamHandle = mStreams[0];
     EXPECT_TRUE(streamHandle != INVALID_STREAM_HANDLE_VALUE);
 


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Introduced the CMAKE_INSTALL_RPATH option for libcurl to ensure runtime discovery of the correct libssl shared object.

*Why was it changed?*
- Some CI runs failed to execute test or sample binaries due to a runtime linker error: `libssl.so.1.1: cannot open shared object file: No such file or directory`
- Even though the required libssl was present in the local build directory, the linker attempted to resolve it using the system default library paths.

<img width="812" alt="image" src="https://github.com/user-attachments/assets/e8990039-819c-4104-b3a8-82498e695a1f" />

Example failure: [CI run](https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/actions/runs/12981868280/job/36200894806)

### Investigation
- The project builds OpenSSL (libssl) and Curl (libcurl) from source.
- At runtime, our binaries correctly link against the locally built Curl.
- However, libcurl in depends on OpenSSL as a peer dependency. Due to the absence of an RPATH, the dynamic linker tries to resolve libssl from the system, resulting in a mismatch when the system default is OpenSSL v3 (as in Ubuntu 24.04), while the binary expects OpenSSL v1.1.

This results in a runtime failure despite all libraries being present locally.
- While setting `LD_LIBRARY_PATH` would work, it’s error-prone and not ideal for end-users or CI. A more robust solution is to explicitly set the RPATH so the binary can locate its dependencies relative to its install location.

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/17d5143a-6218-43fc-bfa6-267fc0abb36a" />

*How was it changed?*
- Added `CMAKE_INSTALL_RPATH` flag for libCurl build: https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_RPATH.html#variable:CMAKE_INSTALL_RPATH
- Used $ORIGIN for the RPATH. This instructs the dynamic linker to search for dependencies in the same directory as the binary.

*What testing was done for the changes?*
- Run the updated CI
- Add Ubuntu 20.04 and 24.04 (previously: Only Ubuntu 22.04) combinations using ECR docker images
  - Add LWS path too (previous: Only OpenSSL)
  - Confirmed all shared library dependencies are correctly resolved using `ldd`.
- Consolidated Mac jobs using a matrix strategy and added a `-DBUILD_DEPENDENCIES=OFF` test combination.

<img width="906" alt="image" src="https://github.com/user-attachments/assets/558d9b50-d12f-413f-8682-c9646363bf39" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.