### PR TITLE
Increase logging verbosity in retries case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - develop
       - master
+
+env:
+  AWS_KVS_LOG_LEVEL: 7
+
 jobs:
   mac-os-build-gcc:
     runs-on: macos-13
@@ -18,7 +22,6 @@ jobs:
     env:
       CC: gcc-14
       CXX: g++-14
-      AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -46,8 +49,6 @@ jobs:
 
   mac-os-build-clang:
     runs-on: macos-13
-    env:
-      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read
@@ -78,8 +79,6 @@ jobs:
 
   mac-os-m1-build-clang:
     runs-on: macos-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read
@@ -113,7 +112,6 @@ jobs:
     env:
       CC: gcc-13
       CXX: g++-13
-      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read
@@ -150,7 +148,6 @@ jobs:
     env:
       CC: gcc-14
       CXX: g++-14
-      AWS_KVS_LOG_LEVEL: 2
       LDFLAGS: -L/usr/local/opt/openssl@3/lib
       CPPFLAGS: -I/usr/local/opt/openssl@3/include
       OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
@@ -182,7 +179,6 @@ jobs:
   mac-os-build-clang-local-openssl:
     runs-on: macos-13
     env:
-      AWS_KVS_LOG_LEVEL: 2
       LDFLAGS: -L/usr/local/opt/openssl@3/lib
       CPPFLAGS: -I/usr/local/opt/openssl@3/include
       OPENSSL_ROOT_DIR: /usr/local/opt/openssl@3/
@@ -216,8 +212,6 @@ jobs:
 
   linux-gcc-code-coverage:
     runs-on: ubuntu-22.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read
@@ -259,7 +253,6 @@ jobs:
     env:
       CC: clang
       CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -293,7 +286,6 @@ jobs:
     env:
       CC: clang
       CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -377,7 +369,6 @@ jobs:
   ubuntu-gcc:
     runs-on: ubuntu-22.04
     env:
-      AWS_KVS_LOG_LEVEL: 2
       CC: gcc
       CXX: g++
     permissions:

--- a/tst/main.cpp
+++ b/tst/main.cpp
@@ -65,6 +65,16 @@ int main(int argc, char** argv)
         if (trial >= MAX_TRIALS) {
             ::testing::GTEST_FLAG(break_on_failure) = breakOnFailure;
         }
+
+        // Increase logging verbosity on retry
+        if (trial >= 1) {
+#ifdef _WIN32
+            _putenv_s("AWS_KVS_LOG_LEVEL", "1");
+#else
+            setenv("AWS_KVS_LOG_LEVEL", "1", 1);
+#endif
+        }
+
         rc = RUN_ALL_TESTS();
 
         // If there were some tests failed, set googletest filter flag to those failed tests.


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Increase logging verbosity when the test fails (retry count > 1).
- Reduce the logging verbosity for the first run in the CI.

*Why was it changed?*
- It's difficult to debug test failures in CI due to excessive log noise from passing tests.
- Increasing log level selectively makes it easier to focus on relevant output when a test fails.

*How was it changed?*
- Set the `AWS_KVS_LOG_LEVEL` environment variable to 1 (VERBOSE) or when the retry count is greater than 1.

*What testing was done for the changes?*
- Run the CI with the changes.
- Verified locally using a failing test case (below)
  - Observed that the first run prints minimal logs.
  - On retry, the log level increases, printing detailed info/debug messages for easier troubleshooting. 

```
export AWS_KVS_LOG_LEVEL=7

./tst/producer_test --gtest_filter="*curl_timeout_idling_force_ack*"
Note: Google Test filter = *curl_timeout_idling_force_ack*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ProducerFunctionalityTest
[ RUN      ] ProducerFunctionalityTest.curl_timeout_idling_force_ack
/Users/me/Downloads/amazon-kinesis-video-streams-producer-c/tst/ProducerFunctionalityTest.cpp:1611: Failure
Expected equality of these values:
  0
  mStreamErrorFnCount
    Which is: 1

[  FAILED  ] ProducerFunctionalityTest.curl_timeout_idling_force_ack (46179 ms)
[----------] 1 test from ProducerFunctionalityTest (46179 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (46179 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ProducerFunctionalityTest.curl_timeout_idling_force_ack

 1 FAILED TEST
Note: Google Test filter = :ProducerFunctionalityTest.curl_timeout_idling_force_ack
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ProducerFunctionalityTest
[ RUN      ] ProducerFunctionalityTest.curl_timeout_idling_force_ack
2025-04-16 02:25:29.759 INFO    SetUp(): 
Setting up test: ProducerFunctionalityTest

2025-04-16 02:25:29.759 INFO    determineKvsControlPlaneEndpointType(): Using LEGACY endpoint from environment
2025-04-16 02:25:29.760 INFO    createKinesisVideoClient(): Creating Kinesis Video Client
2025-04-16 02:25:29.760 WARN    fixupClientInfo(): Connection timeout is invalid...setting to default
2025-04-16 02:25:29.760 WARN    fixupClientInfo(): Completion timeout is invalid...setting to default
2025-04-16 02:25:29.760 VERBOSE normalizeExponentialBackoffConfig(): Thread Id [8655243328]. Exponential backoff retry strategy config - maxRetryCount: [0], maxRetryWaitTime: [160000000], retryFactorTime: [10000000], minTimeToResetRetryState: [900000000], jitterType: [1], jitterFactor: [0], 
2025-04-16 02:25:29.765 VERBOSE resetExponentialBackoffRetryState(): Thread Id [8655243328]. Resetting Exponential Backoff State. Last retry system time [0], retry count so far [0], Current system time [17447703297655610]
2025-04-16 02:25:29.765 VERBOSE exponentialBackoffRetryStrategyWithDefaultConfigCreate(): Created exponential backoff retry strategy state with default configuration.
2025-04-16 02:25:29.765 INFO    heapInitialize(): Initializing native heap with limit size 134217728, spill ratio 0% and flags 0x00000001
2025-04-16 02:25:29.765 INFO    heapInitialize(): Creating AIV heap.
2025-04-16 02:25:29.765 INFO    heapInitialize(): Heap is initialized OK
2025-04-16 02:25:29.767 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
2025-04-16 02:25:29.767 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000002, Next state: 0x0000000000000010, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
2025-04-16 02:25:29.767 INFO    createDeviceResultEvent(): Create device result event.
2025-04-16 02:25:29.767 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000010, Next state: 0x0000000000000040, Current local state retry count [0], Max local state retry count [0], State transition wait time [0] ms
2025-04-16 02:25:29.767 VERBOSE createKinesisVideoClientSync(): Awaiting for the Kinesis Video Client to become ready...
2025-04-16 02:25:29.767 VERBOSE createKinesisVideoClientSync(): Kinesis Video Client is Ready.
2025-04-16 02:25:29.769 INFO    createKinesisVideoStream(): Creating Kinesis Video Stream.
2025-04-16 02:25:29.769 INFO    logStreamInfo(): SDK version: 641c1034202305d4c51d2a584525216f459194f1
2025-04-16 02:25:29.769 DEBUG   logStreamInfo(): Kinesis Video Stream Info
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Stream name: ScaryTestStream_0 
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Streaming type: STREAMING_TYPE_REALTIME 
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Content type: video/h264 
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Max latency (100ns): 300000000
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Fragment duration (100ns): 20000000
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Key frame fragmentation: Yes
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Use frame timecodes: Yes
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Absolute frame timecodes: Yes
2025-04-16 02:25:29.769 DEBUG   logStreamInfo():        Nal adaptation flags: 0
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Average bandwidth (bps): 4194304
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Framerate: 100
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Buffer duration (100ns): 1200000000
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Replay duration (100ns): 100000000
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Connection Staleness duration (100ns): 1200000000
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Store Pressure Policy: 0
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        View Overflow Policy: 0
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Allow stream creation: Yes
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Segment UUID: NULL
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Frame ordering mode: 0
2025-04-16 02:25:29.771 DEBUG   logStreamInfo(): Track list
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Track id: 1
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Track name: kinesis_video
2025-04-16 02:25:29.771 DEBUG   logStreamInfo():        Codec id: V_MPEG4/ISO/AVC
2025-04-16 02:25:29.774 DEBUG   logStreamInfo():        Track type: TRACK_INFO_TYPE_VIDEO
2025-04-16 02:25:29.774 DEBUG   logStreamInfo():        Track cpd: NULL
2025-04-16 02:25:29.774 VERBOSE stepStateMachine(): [STREAM] State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
2025-04-16 02:25:29.774 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000040, Next state: 0x0000000000000040, Current local state retry count [1], Max local state retry count [0], State transition wait time [0] ms
2025-04-16 02:25:29.775 DEBUG   initializeCurlSession(): Curl resolving dual stack by default
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.