### PR TITLE
Add valgrind checks to all of the samples

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -275,14 +275,17 @@ jobs:
 
           echo "Running Valgrind on ${{ matrix.sample-executable.name }}"
           mkdir -p valgrind_logs
+          
+          echo "::group::Application logs for ${{ matrix.sample-executable.name }}"
           valgrind \
             --leak-check=full \
             --show-leak-kinds=all \
             --track-origins=yes \
             --error-exitcode=1 \
-            --log-file=valgrind_logs/valgrind_${{ matrix.sample-executable.name }}.log \
+            --log-file=valgrind_logs/${{ matrix.sample-executable.name }}.log \
             ./${{ matrix.sample-executable.name }} "$KVS_STREAM_NAME" ${{ matrix.sample-executable.args }}
           valgrind_exit_code=$?
+          echo "::endgroup::"
 
           echo "========== Valgrind Output =========="
           cat valgrind_logs/${{ matrix.sample-executable.name }}.log

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -83,7 +83,7 @@ jobs:
           set -x
           file_path="./dependency/libkvspic/kvspic-src/src/client/src/StreamEvent.c"
           string_to_replace='pKinesisVideoStream->streamingAuthInfo.expiration = MIN(expiration, currentTime + MAX_ENFORCED_TOKEN_EXPIRATION_DURATION);'
-          string_to_replace_with='pKinesisVideoStream->streamingAuthInfo.expiration = MIN(expiration, currentTime + MIN_STREAMING_TOKEN_EXPIRATION_DURATION);'
+          string_to_replace_with='pKinesisVideoStream->streamingAuthInfo.expiration = MIN(  expiration, currentTime + MIN_STREAMING_TOKEN_EXPIRATION_DURATION);'
 
           set +e
           echo "Checking if the pattern exists before replacement:"
@@ -273,23 +273,27 @@ jobs:
           set -o pipefail
           set +e
 
-          echo "Running Valgrind on ${{ matrix.sample-executable.name }}"
           mkdir -p valgrind_logs
-          
+
+          LOG_FILE="valgrind_logs/${{ matrix.sample-executable.name }}.log"
+
           echo "::group::Application logs for ${{ matrix.sample-executable.name }}"
           valgrind \
             --leak-check=full \
             --show-leak-kinds=all \
             --track-origins=yes \
             --error-exitcode=1 \
-            --log-file=valgrind_logs/${{ matrix.sample-executable.name }}.log \
+            --log-file="$LOG_FILE" \
             ./${{ matrix.sample-executable.name }} "$KVS_STREAM_NAME" ${{ matrix.sample-executable.args }}
-          valgrind_exit_code=$?
           echo "::endgroup::"
 
           echo "========== Valgrind Output =========="
-          cat valgrind_logs/${{ matrix.sample-executable.name }}.log
+          cat "$LOG_FILE"
           echo "====================================="
 
-          exit "$valgrind_exit_code"
+          if grep -qE "definitely lost: [^0]" "$LOG_FILE" || grep -qE "indirectly lost: [^0]" "$LOG_FILE"; then
+            echo "❌ Valgrind found something definitely or indirectly lost"
+            exit 1
+          fi
+
         shell: bash

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -63,7 +63,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           apt-get update
-          apt-get install -y git cmake build-essential pkg-config libssl-dev libcurl4-openssl-dev mkvtoolnix curl unzip
+          apt-get install -y git cmake build-essential pkg-config libssl-dev libcurl4-openssl-dev mkvtoolnix curl unzip valgrind
 
       - name: Build repository
         run: |

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -74,7 +74,7 @@ jobs:
           fi
 
           mkdir build && cd build
-          cmake .. -DBUILD_DEPENDENCIES=OFF
+          cmake .. -DBUILD_DEPENDENCIES=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
           make -j$num_procs
 
       - name: Change token rotation to 30s
@@ -265,4 +265,28 @@ jobs:
           done < fragments.txt
 
           exit $failed
+        shell: bash
+      - name: Run Valgrind on ${{ matrix.sample-executable.name }} (Linux)
+        if: runner.os == 'Linux'
+        working-directory: ./build
+        run: |
+          set -o pipefail
+          set +e
+
+          echo "Running Valgrind on ${{ matrix.sample-executable.name }}"
+          mkdir -p valgrind_logs
+          valgrind \
+            --leak-check=full \
+            --show-leak-kinds=all \
+            --track-origins=yes \
+            --error-exitcode=1 \
+            --log-file=valgrind_logs/valgrind_${{ matrix.sample-executable.name }}.log \
+            ./${{ matrix.sample-executable.name }} "$KVS_STREAM_NAME" ${{ matrix.sample-executable.args }}
+          valgrind_exit_code=$?
+
+          echo "========== Valgrind Output =========="
+          cat valgrind_logs/${{ matrix.sample-executable.name }}.log
+          echo "====================================="
+
+          exit "$valgrind_exit_code"
         shell: bash

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -83,7 +83,7 @@ jobs:
           set -x
           file_path="./dependency/libkvspic/kvspic-src/src/client/src/StreamEvent.c"
           string_to_replace='pKinesisVideoStream->streamingAuthInfo.expiration = MIN(expiration, currentTime + MAX_ENFORCED_TOKEN_EXPIRATION_DURATION);'
-          string_to_replace_with='pKinesisVideoStream->streamingAuthInfo.expiration = MIN(  expiration, currentTime + MIN_STREAMING_TOKEN_EXPIRATION_DURATION);'
+          string_to_replace_with='pKinesisVideoStream->streamingAuthInfo.expiration = MIN(expiration, currentTime + MIN_STREAMING_TOKEN_EXPIRATION_DURATION);'
 
           set +e
           echo "Checking if the pattern exists before replacement:"


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Ci. Run valgrind with all the samples.
- Change the build type to release build with debug symbols. in case of any memory leaks, we will at least have the line numbers on which the leak occurred for debugging.

*Why was it changed?*
- Adding additional checks to make sure no memory leaks are introduced.

*How was it changed?*
- Add additional step to run valgrind on the linux samples.
- It will run the samples twice now, but it makes the code simpler to read and maintain.

*What testing was done for the changes?*
- Running the CI is the test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.