### PR TITLE
Upgrade from MacOS13 to 15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 #            cxx: g++-14
         cpu:
           - name: Intel
-            image: macos-13
+            image: macos-15-intel
           - name: Apple Silicon
             image: macos-15
         openssl:


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- CI: Runner type used

*Why was it changed?*
- MacOS 13 (x86_64) is being deprecated and being replaced with `macos-15-intel`
- https://github.com/actions/runner-images/issues/13045

*How was it changed?*
- Updated the runner type in the ci configuration file

*What testing was done for the changes?*
- If the CI passes, the migration completed successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
