### PR TITLE
Ultra-verbose log enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(BUILD_COMMON_CURL "Whether or not to build ProducerC curl common library"
 option(BUILD_OPENSSL_PLATFORM "If buildng OpenSSL what is the target platform" OFF)
 option(LOCAL_OPENSSL_BUILD "Whether or not to use local OpenSSL build" OFF)
 option(CONSTRAINED_DEVICE "Change pthread stack size" OFF)
+option(KVS_ENABLE_VERBOSE_LOGS "Enable ENTERS/LEAVES logs (at LOG_LEVEL_VERBOSE)" OFF)
 
 # Dependency Flags
 option(CURL_USE_FPIC "Compile libcurl with -fPIC flag" ON)
@@ -126,6 +127,11 @@ endif()
 
 if(AWS_KVS_USE_DUAL_STACK_ENDPOINT_ONLY)
     add_definitions(-DAWS_KVS_USE_DUAL_STACK_ENDPOINT_ONLY)
+endif()
+
+if (KVS_ENABLE_VERBOSE_LOGS)
+    add_definitions(-DLOG_STREAMING)
+    message(STATUS "Enabled ENTERS/LEAVES logs")
 endif()
 
 if(BUILD_DEPENDENCIES)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you wish to cross-compile `CC` and `CXX` are respected when building the libr
 You can pass the following options to `cmake ..`.
 
 * `-DBUILD_DEPENDENCIES` -- Whether or not to build depending libraries from source
+* `-DKVS_ENABLE_VERBOSE_LOGS` -- Build with `ENTERS()` and `LEAVES()` logs enabled, which are `LOG_LEVEL_VERBOSE`. Default is OFF.
 * `-DBUILD_TEST=TRUE` -- Build unit/integration tests, may be useful for confirm support for your device. `./tst/producer_test`
 * `-DCODE_COVERAGE` --  Enable coverage reporting
 * `-DCOMPILER_WARNINGS` -- Enable all compiler warnings
@@ -177,10 +178,14 @@ To set a log level, you can set it using the deviceInfo structure.
 pDeviceInfo->clientInfo.loggerLogLevel = LOG_LEVEL_DEBUG;
 ```
 
-By default, our samples set the log level to `LOG_LEVEL_DEBUG`.
+The samples set the loggerLogLevel based on the log level environment variable. If not set, it falls back to `LOG_LEVEL_DEBUG`.
+```sh
+export AWS_KVS_LOG_LEVEL=1
+```
 
-The SDK also tracks entry and exit of functions which increases the verbosity of the logs. This will be useful when you want to track the transitions within the codebase. To do so, you need to set log level to `LOG_LEVEL_VERBOSE` and add the following to the cmake file:
-`add_definitions(-DLOG_STREAMING)`
+The SDK also tracks entry and exit of functions which increases the verbosity of the logs.
+This will be useful when you want to track the transitions within the codebase.
+To enable this feature, set the log level to LOG_LEVEL_VERBOSE and compile the code with `-DKVS_ENABLE_VERBOSE_LOGS=ON`.
 Note: This log level is extremely VERBOSE and could flood the files if using file based logging strategy.
 
 ### Run unit tests

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -16,3 +16,21 @@ VOID getEndpointOverride(PCHAR outUrl, SIZE_T maxLen)
 
     SNPRINTF(outUrl, maxLen, "%s", envValue);
 }
+
+UINT32 getSampleLogLevel()
+{
+    UINT32 userLogLevel;
+    const char* envValue = GETENV(DEBUG_LOG_LEVEL_ENV_VAR);
+
+    // Default to debug
+    if (IS_NULL_OR_EMPTY_STRING(envValue)) {
+        return LOG_LEVEL_DEBUG;
+    }
+
+    if (STATUS_FAILED(STRTOUI32((PCHAR) envValue, NULL, 10, &userLogLevel))) {
+        printf("failed to parse %s, set to debug\n", DEBUG_LOG_LEVEL_ENV_VAR);
+        userLogLevel = LOG_LEVEL_DEBUG;
+    }
+
+    return userLogLevel;
+}

--- a/samples/KvsAudioOnlyStreamingSample.c
+++ b/samples/KvsAudioOnlyStreamingSample.c
@@ -182,7 +182,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     // default storage size is 128MB. Use setDeviceInfoStorageSize after create to change storage size.
     CHK_STATUS(createDefaultDeviceInfo(&pDeviceInfo));
     // adjust members of pDeviceInfo here if needed
-    pDeviceInfo->clientInfo.loggerLogLevel = LOG_LEVEL_DEBUG;
+    pDeviceInfo->clientInfo.loggerLogLevel = getSampleLogLevel();
 
     // generate audio cpd
     if (!STRCMP(audioCodec, AUDIO_CODEC_NAME_ALAW)) {

--- a/samples/KvsAudioVideoStreamingSample.c
+++ b/samples/KvsAudioVideoStreamingSample.c
@@ -286,7 +286,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     // default storage size is 128MB. Use setDeviceInfoStorageSize after create to change storage size.
     CHK_STATUS(createDefaultDeviceInfo(&pDeviceInfo));
     // adjust members of pDeviceInfo here if needed
-    pDeviceInfo->clientInfo.loggerLogLevel = LOG_LEVEL_DEBUG;
+    pDeviceInfo->clientInfo.loggerLogLevel = getSampleLogLevel();
 
     // generate audio cpd
     if (!STRCMP(audioCodec, AUDIO_CODEC_NAME_ALAW)) {

--- a/samples/KvsVideoOnlyOfflineStreamingSample.c
+++ b/samples/KvsVideoOnlyOfflineStreamingSample.c
@@ -126,7 +126,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     // default storage size is 128MB. Use setDeviceInfoStorageSize after create to change storage size.
     CHK_STATUS(createDefaultDeviceInfo(&pDeviceInfo));
     // adjust members of pDeviceInfo here if needed
-    pDeviceInfo->clientInfo.loggerLogLevel = LOG_LEVEL_DEBUG;
+    pDeviceInfo->clientInfo.loggerLogLevel = getSampleLogLevel();
     pDeviceInfo->storageInfo.storageSize = DEFAULT_STORAGE_SIZE;
 
     CHK_STATUS(

--- a/samples/KvsVideoOnlyRealtimeStreamingSample.c
+++ b/samples/KvsVideoOnlyRealtimeStreamingSample.c
@@ -137,7 +137,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     // default storage size is 128MB. Use setDeviceInfoStorageSize after create to change storage size.
     CHK_STATUS(createDefaultDeviceInfo(&pDeviceInfo));
     // adjust members of pDeviceInfo here if needed
-    pDeviceInfo->clientInfo.loggerLogLevel = LOG_LEVEL_DEBUG;
+    pDeviceInfo->clientInfo.loggerLogLevel = getSampleLogLevel();
     pDeviceInfo->storageInfo.storageSize = DEFAULT_STORAGE_SIZE;
 
     CHK_STATUS(

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -25,6 +25,7 @@ extern "C" {
 #define MAX_NUMBER_OF_LOG_FILES  5
 
 VOID getEndpointOverride(PCHAR, SIZE_T);
+UINT32 getSampleLogLevel();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Make it easier to enable ENTERS/LEAVES logs
- Have the samples set the log level

*Why was it changed?*
- Make it an official cmake option
- Make the samples easier to use and not require code modification to run with different levels
- Note: By default, if the log level isn't set in the deviceInfo, PIC defaults to WARN. However, the samples prefer to default to DEBUG (otherwise it looks like nothing is happening), so we need to implement the same parsing logic with a different default.

*How was it changed?*
- Parse the env and pass it in as part of the deviceInfo.

*What testing was done for the changes?*
- Ran it locally to check the ENTERS/LEAVES logs are present. Example:

```
2026-02-17 20:40:30.014 VERBOSE putKinesisVideoFrame(): Enter
2026-02-17 20:40:30.014 VERBOSE putKinesisVideoFrame(): Putting frame into an Kinesis Video stream.
2026-02-17 20:40:30.014 VERBOSE semaphoreAcquireInternal(): Enter
2026-02-17 20:40:30.014 VERBOSE semaphoreAcquireInternal(): Leave
2026-02-17 20:40:30.014 VERBOSE semaphoreAcquireInternal(): Enter
2026-02-17 20:40:30.014 VERBOSE semaphoreAcquireInternal(): Leave
2026-02-17 20:40:30.014 VERBOSE putKinesisVideoFrame(): [demo-stream] debug frame info pts: 3000000, dts: 3000000, duration: 0, size: 477, trackId: 2, isKey 0
2026-02-17 20:40:30.014 VERBOSE frameOrderCoordinatorPutFrame(): Enter
2026-02-17 20:40:30.014 VERBOSE frameOrderCoordinatorPutFrame(): Leave
2026-02-17 20:40:30.014 VERBOSE semaphoreReleaseInternal(): Enter
2026-02-17 20:40:30.014 VERBOSE semaphoreReleaseInternal(): Leave
2026-02-17 20:40:30.014 VERBOSE semaphoreReleaseInternal(): Enter
2026-02-17 20:40:30.014 VERBOSE semaphoreReleaseInternal(): Leave
2026-02-17 20:40:30.014 VERBOSE putKinesisVideoFrame(): Leave
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
