### PR TITLE
Prevent undefined behavior when logging null HTTP response data

### DIFF
--- a/src/source/Response.c
+++ b/src/source/Response.c
@@ -464,8 +464,9 @@ STATUS curlCompleteSync(PCurlResponse pCurlResponse)
             STRCAT(headers, header->data);
         }
 
-        DLOGW("[%s] HTTP Error %lu : Response: %s\nRequest URL: %s\nRequest Headers:%s", pCurlResponse->pCurlRequest->streamName,
-              pCurlResponse->callInfo.httpStatus, pCurlResponse->callInfo.responseData, url, headers);
+        DLOGW("[%s] HTTP Error %lu : Response: %.*s\nRequest URL: %s\nRequest Headers:%s", pCurlResponse->pCurlRequest->streamName,
+              pCurlResponse->callInfo.httpStatus, pCurlResponse->callInfo.responseDataLen,
+              pCurlResponse->callInfo.responseData != NULL ? pCurlResponse->callInfo.responseData : "", url, headers);
     }
 
 CleanUp:


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Modified the error logging in `curlCompleteSync` in `src/source/Response.c` to safely handle a NULL `responseData`.

*Why was it changed?*
- When `responseData` is NULL, passing it to a `%s` format specifier is undefined behavior, which can cause a crash in some systems.

*How was it changed?*
- Changed the format specifier from `%s` to `%.*s` with `responseDataLen` to bound the print length.
- Added a NULL check on `responseData`, substituting an empty string if it is NULL.

*What testing was done for the changes?*
- CI/CD to verify no regressions
- Ran the sample locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
