### PR TITLE
Add explicit permission blocks to cross-compilation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,8 @@ jobs:
 
   arm64-cross-compilation:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -359,6 +361,8 @@ jobs:
 
   linux-aarch64-cross-compilation:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
@@ -383,6 +387,8 @@ jobs:
 
   arm32-cross-compilation:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       CC: arm-linux-gnueabi-gcc
       CXX: arm-linux-gnueabi-g++
@@ -410,6 +416,8 @@ jobs:
 
   linux-build-gcc-static:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add readonly permissions to the cross-compilation jobs

*Why was it changed?*
- Following best practices

*How was it changed?*
- Add readonly permission to these build jobs.

*What testing was done for the changes?*
- CI/CD should still pass. No AWS credentials are accessed in these jobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
