### PR TITLE
Use correct tag @7.1.1 for aws-actions/stale-issue-cleanup

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -5,7 +5,6 @@ name: Close Stale Issues
 on:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
 
 permissions:
   issues: write
@@ -14,9 +13,6 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Close stale issues
-    env:
-      # enable github actions debug log for just this workflow
-      ACTIONS_STEP_DEBUG: true
     steps:
       - uses: aws-actions/stale-issue-cleanup@v7.1.1
         with:

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -14,6 +14,9 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Close stale issues
+    env:
+      # enable github actions debug log for just this workflow
+      ACTIONS_STEP_DEBUG: true
     steps:
       - uses: aws-actions/stale-issue-cleanup@v7.1.1
         with:
@@ -22,7 +25,7 @@ jobs:
 
           # labels to be added
           stale-issue-label: closing-soon
-          exempt-issue-labels: enhancement,pending-research,pending-action,needs-triage
+          exempt-issue-labels: enhancement,pending-research,pending-action,needs-triage,bug
           response-requested-label: pending-response
 
           closed-for-staleness-label: closed-for-staleness

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Close stale issues
     steps:
-      - uses: aws-actions/stale-issue-cleanup@v7
+      - uses: aws-actions/stale-issue-cleanup@v7.1.1
         with:
           ancient-issue-message: This is a very old issue. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to open a new one.
           stale-issue-message: It looks like this issue has not been active for 10 days. If the issue is not resolved, please add an update to the ticket, else it will be automatically resolved in a few days.

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -5,6 +5,7 @@ name: Close Stale Issues
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   issues: write


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Change github repo tag for `aws-actions/stale-issue-cleanup` (dependency workflow)

*Why was it changed?*
- The current tag v7 is an invalid tag, only v7.0.0, v7.0.1, v7.1.0, v7.1.1 are available (https://github.com/aws-actions/stale-issue-cleanup). This results in [failure](https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/actions/runs/25295874745) of workflow 

*How was it changed?*
- Change `close-stale-issues.yml` file to use v7.1.1 instead of v7

*What testing was done for the changes?*
-  The fix was tested in a forked repo. ([workflow link](https://github.com/vabhasin/amazon-kinesis-video-streams-producer-c/actions/runs/25294348780))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
