### PR TITLE
Add IMDSv2 credentials provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ To run the samples with IoT credential provider:
 3. Build the changes: `make`
 4. Run the sample using the instructions in previous section.
 
+### Credential Configuration
+
+The samples use a credential resolution chain that checks each source in order and uses the first one available:
+
+1. **Environment variables** (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) -- Static credentials provided via environment. Optional `AWS_SESSION_TOKEN` for temporary credentials.
+2. **EC2 Instance Metadata Service (IMDSv2)** -- Automatically retrieves temporary credentials from the EC2 instance profile. Only IMDSv2 is supported. The instance must have an IAM role attached and the metadata service must be accessible.
+
+If using the IoT credential provider (`IOT_CORE_ENABLE_CREDENTIALS`), the above chain is bypassed entirely and IoT certificates are used instead.
+
+For programmatic usage, the following credential provider APIs are available:
+* `createDefaultCallbacksProviderWithAwsCredentials()` -- Static credentials
+* `createDefaultCallbacksProviderWithEc2Credentials()` -- EC2 IMDS (IMDSv2)
+* `createDefaultCallbacksProviderWithIotCertificate()` -- IoT certificate-based
+* `createDefaultCallbacksProviderWithFileAuth()` -- File-based credentials
+
 ### Fragment metadata
 
 `./kvsVideoOnlyRealtimeStreamingSample` is the only sample that has the [fragment metadata](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-meta.html) implemented out of the box.

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -44,6 +44,8 @@ STATUS createSampleCallbacksProvider(PCHAR region, PCHAR caCertPath, PCHAR userA
     PStreamCallbacks pStreamCallbacks = NULL;
     CHAR endpointOverride[MAX_URI_CHAR_LEN];
 
+    SET_LOGGER_LOG_LEVEL(getSampleLogLevel());
+
     CHK(ppClientCallbacks != NULL, STATUS_NULL_ARG);
 
     getEndpointOverride(endpointOverride, SIZEOF(endpointOverride));

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -53,11 +53,12 @@ STATUS createSampleCallbacksProvider(PCHAR region, PCHAR caCertPath, PCHAR userA
     sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
 
     if (accessKey != NULL && secretKey != NULL) {
+        DLOGI("Using environment variable credentials");
         CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region,
                                                                                        caCertPath, userAgentPostfix, customUserAgent,
                                                                                        endpointOverride, ppClientCallbacks));
     } else {
-        DLOGI("No env credentials found, falling back to EC2 instance credentials");
+        DLOGI("Environment variable credentials not found, using EC2 IMDS credential provider");
         CHK_STATUS(createAbstractDefaultCallbacksProvider(DEFAULT_CALLBACK_CHAIN_COUNT, API_CALL_CACHE_TYPE_ALL,
                                                           ENDPOINT_UPDATE_PERIOD_SENTINEL_VALUE, region, endpointOverride, caCertPath,
                                                           userAgentPostfix, customUserAgent, ppClientCallbacks));

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -34,3 +34,44 @@ UINT32 getSampleLogLevel()
 
     return userLogLevel;
 }
+
+STATUS createSampleCallbacksProvider(PCHAR region, PCHAR caCertPath, PCHAR userAgentPostfix, PCHAR customUserAgent,
+                                     PClientCallbacks* ppClientCallbacks)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PCHAR accessKey = NULL, secretKey = NULL, sessionToken = NULL;
+    PAuthCallbacks pAuthCallbacks = NULL;
+    PStreamCallbacks pStreamCallbacks = NULL;
+    CHAR endpointOverride[MAX_URI_CHAR_LEN];
+
+    CHK(ppClientCallbacks != NULL, STATUS_NULL_ARG);
+
+    getEndpointOverride(endpointOverride, SIZEOF(endpointOverride));
+
+    accessKey = GETENV(ACCESS_KEY_ENV_VAR);
+    secretKey = GETENV(SECRET_KEY_ENV_VAR);
+    sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
+
+    if (accessKey != NULL && secretKey != NULL) {
+        CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region,
+                                                                                       caCertPath, userAgentPostfix, customUserAgent,
+                                                                                       endpointOverride, ppClientCallbacks));
+    } else {
+        DLOGI("No env credentials found, falling back to EC2 instance credentials");
+        CHK_STATUS(createAbstractDefaultCallbacksProvider(DEFAULT_CALLBACK_CHAIN_COUNT, API_CALL_CACHE_TYPE_ALL,
+                                                          ENDPOINT_UPDATE_PERIOD_SENTINEL_VALUE, region, endpointOverride, caCertPath,
+                                                          userAgentPostfix, customUserAgent, ppClientCallbacks));
+        CHK_STATUS(createEc2AuthCallbacks(*ppClientCallbacks, &pAuthCallbacks));
+        CHK_STATUS(createContinuousRetryStreamCallbacks(*ppClientCallbacks, &pStreamCallbacks));
+    }
+
+CleanUp:
+
+    CHK_LOG_ERR(retStatus);
+
+    if (STATUS_FAILED(retStatus) && ppClientCallbacks != NULL && *ppClientCallbacks != NULL) {
+        freeCallbacksProvider(ppClientCallbacks);
+    }
+
+    return retStatus;
+}

--- a/samples/KvsAudioOnlyStreamingSample.c
+++ b/samples/KvsAudioOnlyStreamingSample.c
@@ -94,7 +94,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     CLIENT_HANDLE clientHandle = INVALID_CLIENT_HANDLE_VALUE;
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     STATUS retStatus = STATUS_SUCCESS;
-    PCHAR accessKey = NULL, secretKey = NULL, sessionToken = NULL, streamName = NULL, region = NULL, cacertPath = NULL;
+    PCHAR streamName = NULL, region = NULL, cacertPath = NULL;
     UINT64 streamStopTime, streamingDuration = DEFAULT_STREAM_DURATION, fileSize = 0;
     TID audioSendTid;
     SampleCustomData data;
@@ -124,11 +124,6 @@ INT32 main(INT32 argc, CHAR* argv[])
                argv[0]);
         CHK(FALSE, STATUS_INVALID_ARG);
     }
-    if ((accessKey = GETENV(ACCESS_KEY_ENV_VAR)) == NULL || (secretKey = GETENV(SECRET_KEY_ENV_VAR)) == NULL) {
-        printf("Error missing credentials\n");
-        CHK(FALSE, STATUS_INVALID_ARG);
-    }
-    sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
 #endif
 
     if (argc >= 5) {
@@ -158,7 +153,6 @@ INT32 main(INT32 argc, CHAR* argv[])
     printf("Done loading audio frames.\n");
 
     cacertPath = GETENV(CACERT_PATH_ENV_VAR);
-    sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     streamName = pIotCoreThingName;
@@ -226,8 +220,7 @@ INT32 main(INT32 argc, CHAR* argv[])
                                                                                    cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
                                                                                    NULL, endpointOverride, &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
-                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
+    CHK_STATUS(createSampleCallbacksProvider(region, cacertPath, NULL, NULL, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/KvsAudioVideoStreamingSample.c
+++ b/samples/KvsAudioVideoStreamingSample.c
@@ -176,7 +176,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     CLIENT_HANDLE clientHandle = INVALID_CLIENT_HANDLE_VALUE;
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     STATUS retStatus = STATUS_SUCCESS;
-    PCHAR accessKey = NULL, secretKey = NULL, sessionToken = NULL, streamName = NULL, region = NULL, cacertPath = NULL;
+    PCHAR streamName = NULL, region = NULL, cacertPath = NULL;
     UINT64 streamStopTime, streamingDuration = DEFAULT_STREAM_DURATION, fileSize = 0;
     TID audioSendTid, videoSendTid;
     SampleCustomData data;
@@ -210,11 +210,6 @@ INT32 main(INT32 argc, CHAR* argv[])
                argv[0]);
         CHK(FALSE, STATUS_INVALID_ARG);
     }
-    if ((accessKey = GETENV(ACCESS_KEY_ENV_VAR)) == NULL || (secretKey = GETENV(SECRET_KEY_ENV_VAR)) == NULL) {
-        printf("Error missing credentials\n");
-        CHK(FALSE, STATUS_INVALID_ARG);
-    }
-    sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
 #endif
 
     if (argc == 7) {
@@ -332,8 +327,7 @@ INT32 main(INT32 argc, CHAR* argv[])
                                                                                    cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
                                                                                    NULL, endpointOverride, &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
-                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
+    CHK_STATUS(createSampleCallbacksProvider(region, cacertPath, NULL, NULL, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/KvsVideoOnlyOfflineStreamingSample.c
+++ b/samples/KvsVideoOnlyOfflineStreamingSample.c
@@ -53,7 +53,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     CLIENT_HANDLE clientHandle = INVALID_CLIENT_HANDLE_VALUE;
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     STATUS retStatus = STATUS_SUCCESS;
-    PCHAR accessKey = NULL, secretKey = NULL, sessionToken = NULL, streamName = NULL, region = NULL, cacertPath = NULL;
+    PCHAR streamName = NULL, region = NULL, cacertPath = NULL;
     CHAR frameFilePath[MAX_PATH_LEN + 1];
     Frame frame;
     BYTE frameBuffer[200000]; // Assuming this is enough
@@ -82,11 +82,6 @@ INT32 main(INT32 argc, CHAR* argv[])
               argv[0]);
         CHK(FALSE, STATUS_INVALID_ARG);
     }
-    if ((accessKey = GETENV(ACCESS_KEY_ENV_VAR)) == NULL || (secretKey = GETENV(SECRET_KEY_ENV_VAR)) == NULL) {
-        DLOGE("Error missing credentials");
-        CHK(FALSE, STATUS_INVALID_ARG);
-    }
-    sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
 #endif
 
     MEMSET(frameFilePath, 0x00, MAX_PATH_LEN + 1);
@@ -142,8 +137,7 @@ INT32 main(INT32 argc, CHAR* argv[])
                                                                                    cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
                                                                                    NULL, endpointOverride, &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
-                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
+    CHK_STATUS(createSampleCallbacksProvider(region, cacertPath, NULL, NULL, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/KvsVideoOnlyRealtimeStreamingSample.c
+++ b/samples/KvsVideoOnlyRealtimeStreamingSample.c
@@ -59,7 +59,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     CLIENT_HANDLE clientHandle = INVALID_CLIENT_HANDLE_VALUE;
     STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
     STATUS retStatus = STATUS_SUCCESS;
-    PCHAR accessKey = NULL, secretKey = NULL, sessionToken = NULL, streamName = NULL, region = NULL, cacertPath = NULL;
+    PCHAR streamName = NULL, region = NULL, cacertPath = NULL;
     CHAR frameFilePath[MAX_PATH_LEN + 1], metadataKey[METADATA_MAX_KEY_LENGTH + 1], metadataValue[METADATA_MAX_VALUE_LENGTH + 1];
     Frame frame, eofr = EOFR_FRAME_INITIALIZER;
     BYTE frameBuffer[200000]; // Assuming this is enough
@@ -89,11 +89,6 @@ INT32 main(INT32 argc, CHAR* argv[])
               argv[0]);
         CHK(FALSE, STATUS_INVALID_ARG);
     }
-    if ((accessKey = GETENV(ACCESS_KEY_ENV_VAR)) == NULL || (secretKey = GETENV(SECRET_KEY_ENV_VAR)) == NULL) {
-        DLOGE("Error missing credentials");
-        CHK(FALSE, STATUS_INVALID_ARG);
-    }
-    sessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
 #endif
 
     cacertPath = GETENV(CACERT_PATH_ENV_VAR);
@@ -153,8 +148,7 @@ INT32 main(INT32 argc, CHAR* argv[])
                                                                                    cacertPath, pIotCoreRoleAlias, pIotCoreThingName, region, NULL,
                                                                                    NULL, endpointOverride, &pClientCallbacks));
 #else
-    CHK_STATUS(createDefaultCallbacksProviderWithAwsCredentialsAndEndpointOverride(accessKey, secretKey, sessionToken, MAX_UINT64, region, cacertPath,
-                                                                                   NULL, NULL, endpointOverride, &pClientCallbacks));
+    CHK_STATUS(createSampleCallbacksProvider(region, cacertPath, NULL, NULL, &pClientCallbacks));
 #endif
 
     if (NULL != GETENV(ENABLE_FILE_LOGGING)) {

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -26,6 +26,7 @@ extern "C" {
 
 VOID getEndpointOverride(PCHAR, SIZE_T);
 UINT32 getSampleLogLevel();
+STATUS createSampleCallbacksProvider(PCHAR, PCHAR, PCHAR, PCHAR, PClientCallbacks*);
 
 #ifdef __cplusplus
 }

--- a/src/include/com/amazonaws/kinesis/video/common/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/common/Include.h
@@ -762,6 +762,29 @@ PUBLIC_API STATUS createCurlEc2CredentialProviderWithTime(GetCurrentTimeFunc, UI
 PUBLIC_API STATUS freeEc2CredentialProvider(PAwsCredentialProvider*);
 
 /**
+ * @brief Creates an EC2 IMDS (IMDSv2) based AWS credential provider object using libWebSockets
+ *
+ * Retrieves temporary credentials from the EC2 Instance Metadata Service.
+ * The instance must have an IAM role attached.
+ *
+ * @param[out] PAwsCredentialProvider* Constructed AWS credentials provider object
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS createLwsEc2CredentialProvider(PAwsCredentialProvider*);
+
+/**
+ * @brief Creates an EC2 IMDS (IMDSv2) based AWS credential provider object with custom time function using libWebSockets
+ *
+ * @param[in] GetCurrentTimeFunc Custom current time function
+ * @param[in] UINT64 function custom data
+ * @param[out] PAwsCredentialProvider* Constructed AWS credentials provider object
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS createLwsEc2CredentialProviderWithTime(GetCurrentTimeFunc, UINT64, PAwsCredentialProvider*);
+
+/**
  * @brief Creates a File based AWS credential provider object
  *
  * @param[in] PCHAR Credentials file path

--- a/src/include/com/amazonaws/kinesis/video/common/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/common/Include.h
@@ -71,6 +71,10 @@ extern "C" {
 #define STATUS_IOT_NULL_AWS_CREDS                   STATUS_COMMON_BASE + 0x00000003
 #define STATUS_IOT_INVALID_URI_LEN                  STATUS_COMMON_BASE + 0x00000004
 #define STATUS_TIMESTAMP_STRING_UNRECOGNIZED_FORMAT STATUS_COMMON_BASE + 0x00000005
+#define STATUS_IMDS_INVALID_RESPONSE_LENGTH         STATUS_COMMON_BASE + 0x00000006
+#define STATUS_IMDS_NULL_AWS_CREDS                  STATUS_COMMON_BASE + 0x00000007
+#define STATUS_IMDS_TOKEN_FETCH_FAILED              STATUS_COMMON_BASE + 0x00000008
+#define STATUS_IMDS_ROLE_FETCH_FAILED               STATUS_COMMON_BASE + 0x00000009
 /*!@} */
 
 /**
@@ -82,7 +86,8 @@ extern "C" {
      (error) == STATUS_IOT_NULL_AWS_CREDS || (error) == STATUS_IOT_INVALID_URI_LEN || (error) == STATUS_IOT_EXPIRATION_OCCURS_IN_PAST ||             \
      (error) == STATUS_IOT_EXPIRATION_PARSING_FAILED || (error) == STATUS_IOT_CREATE_LWS_CONTEXT_FAILED ||                                           \
      (error) == STATUS_FILE_CREDENTIAL_PROVIDER_OPEN_FILE_FAILED || (error) == STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_LENGTH ||                \
-     (error) == STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT)
+     (error) == STATUS_FILE_CREDENTIAL_PROVIDER_INVALID_FILE_FORMAT || (error) == STATUS_IMDS_INVALID_RESPONSE_LENGTH ||                             \
+     (error) == STATUS_IMDS_NULL_AWS_CREDS || (error) == STATUS_IMDS_TOKEN_FETCH_FAILED || (error) == STATUS_IMDS_ROLE_FETCH_FAILED)
 
 /////////////////////////////////////////////////////
 /// Lengths of different character arrays
@@ -723,6 +728,38 @@ PUBLIC_API STATUS createLwsIotCredentialProviderWithTime(PCHAR, PCHAR, PCHAR, PC
  * @return STATUS code of the execution. STATUS_SUCCESS on success
  */
 PUBLIC_API STATUS freeIotCredentialProvider(PAwsCredentialProvider*);
+
+/**
+ * @brief Creates an EC2 IMDS (IMDSv2) based AWS credential provider object using libCurl
+ *
+ * Retrieves temporary credentials from the EC2 Instance Metadata Service.
+ * The instance must have an IAM role attached.
+ *
+ * @param[out] PAwsCredentialProvider* Constructed AWS credentials provider object
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS createCurlEc2CredentialProvider(PAwsCredentialProvider*);
+
+/**
+ * @brief Creates an EC2 IMDS (IMDSv2) based AWS credential provider object with custom time function
+ *
+ * @param[in] GetCurrentTimeFunc Custom current time function
+ * @param[in] UINT64 function custom data
+ * @param[out] PAwsCredentialProvider* Constructed AWS credentials provider object
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS createCurlEc2CredentialProviderWithTime(GetCurrentTimeFunc, UINT64, PAwsCredentialProvider*);
+
+/**
+ * @brief Frees an EC2 IMDS based Aws credential provider object
+ *
+ * @param[in,out] PAwsCredentialProvider* Object to be destroyed.
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS freeEc2CredentialProvider(PAwsCredentialProvider*);
 
 /**
  * @brief Creates a File based AWS credential provider object

--- a/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/cproducer/Include.h
@@ -429,6 +429,26 @@ PUBLIC_API STATUS createDefaultCallbacksProviderWithIotCertificateAndTimeouts(PC
 PUBLIC_API STATUS createDefaultCallbacksProviderWithFileAuth(PCHAR, PCHAR, PCHAR, PCHAR, PCHAR, PClientCallbacks*);
 
 /**
+ * Creates a default callbacks provider that uses EC2 instance metadata (IMDSv2)
+ * for credential retrieval.
+ *
+ * NOTE: The caller is responsible for releasing the structure by calling
+ * the corresponding {@link freeCallbackProvider} API.
+ *
+ * NOTE: This provider only supports IMDSv2 (token-based). The instance must
+ * have an IAM role attached and IMDSv2 accessible.
+ *
+ * @param[in,opt] PCHAR AWS region
+ * @param[in,opt] PCHAR CA Cert path
+ * @param[in,opt] PCHAR User agent name (Use NULL)
+ * @param[in,opt] PCHAR Custom user agent to be used in the API calls
+ * @param[out] PClientCallbacks* Returned pointer to callbacks provider
+ *
+ * @return STATUS code of the execution
+ */
+PUBLIC_API STATUS createDefaultCallbacksProviderWithEc2Credentials(PCHAR, PCHAR, PCHAR, PCHAR, PClientCallbacks*);
+
+/**
  * Creates a default callbacks provider that uses auth callbacks as auth method.
  *
  * NOTE: The caller is responsible for releasing the structure by calling
@@ -788,6 +808,31 @@ PUBLIC_API STATUS createIotAuthCallbacksWithTimeouts(PClientCallbacks, PCHAR, PC
  * @return STATUS status of operation
  */
 PUBLIC_API STATUS freeIotAuthCallbacks(PAuthCallbacks*);
+
+/**
+ * Creates the EC2 IMDS Credentials auth callbacks
+ *
+ * NOTE: The caller is responsible for releasing the structure by calling
+ * the corresponding free API.
+ *
+ * NOTE: Only IMDSv2 is supported. The EC2 instance must have an IAM role
+ * attached and the instance metadata service must be accessible.
+ *
+ * @param[in] PCallbacksProvider Pointer to callback provider
+ * @param[in,out] PAuthCallbacks* Pointer to pointer to AuthCallback struct
+ *
+ * @return STATUS status of operation
+ */
+PUBLIC_API STATUS createEc2AuthCallbacks(PClientCallbacks, PAuthCallbacks*);
+
+/**
+ * Frees the EC2 IMDS Credential auth callbacks
+ *
+ * @param[in,out] PAuthCallbacks* pointer to AuthCallback provider object
+ *
+ * @return STATUS status of operation
+ */
+PUBLIC_API STATUS freeEc2AuthCallbacks(PAuthCallbacks*);
 
 /**
  * Creates the File Credentials auth callbacks

--- a/src/source/CallbacksProvider.c
+++ b/src/source/CallbacksProvider.c
@@ -285,6 +285,53 @@ CleanUp:
     return retStatus;
 }
 
+STATUS createDefaultCallbacksProviderWithEc2Credentials(PCHAR region, PCHAR caCertPath, PCHAR userAgentPostfix, PCHAR customUserAgent,
+                                                        PClientCallbacks* ppClientCallbacks)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PCallbacksProvider pCallbacksProvider = NULL;
+    PAuthCallbacks pAuthCallbacks = NULL;
+    PStreamCallbacks pStreamCallbacks = NULL;
+
+    CHK_STATUS(createAbstractDefaultCallbacksProvider(DEFAULT_CALLBACK_CHAIN_COUNT, API_CALL_CACHE_TYPE_ALL, ENDPOINT_UPDATE_PERIOD_SENTINEL_VALUE,
+                                                      region, EMPTY_STRING, caCertPath, userAgentPostfix, customUserAgent, ppClientCallbacks));
+
+    pCallbacksProvider = (PCallbacksProvider) *ppClientCallbacks;
+
+    CHK_STATUS(createEc2AuthCallbacks((PClientCallbacks) pCallbacksProvider, &pAuthCallbacks));
+
+    CHK_STATUS(createContinuousRetryStreamCallbacks((PClientCallbacks) pCallbacksProvider, &pStreamCallbacks));
+
+CleanUp:
+
+    if (STATUS_FAILED(retStatus)) {
+        if (pCallbacksProvider != NULL) {
+            freeCallbacksProvider((PClientCallbacks*) &pCallbacksProvider);
+        }
+
+        if (pAuthCallbacks != NULL) {
+            freeEc2AuthCallbacks(&pAuthCallbacks);
+        }
+
+        if (pStreamCallbacks != NULL) {
+            freeContinuousRetryStreamCallbacks(&pStreamCallbacks);
+        }
+
+        pCallbacksProvider = NULL;
+    }
+
+    CHK_LOG_ERR(retStatus);
+
+    // Set the return value if it's not NULL
+    if (ppClientCallbacks != NULL) {
+        *ppClientCallbacks = (PClientCallbacks) pCallbacksProvider;
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS createDefaultCallbacksProviderWithAuthCallbacks(PAuthCallbacks pAuthCallbacks, PCHAR region, PCHAR caCertPath, PCHAR userAgentPostfix,
                                                        PCHAR customUserAgent, PClientCallbacks* ppClientCallbacks)
 {

--- a/src/source/Common/Curl/CurlCall.c
+++ b/src/source/Common/Curl/CurlCall.c
@@ -55,6 +55,18 @@ STATUS blockingCurlCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
         curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
     }
 
+    if (pRequestInfo->verb == HTTP_REQUEST_VERB_PUT) {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, HTTP_REQUEST_VERB_PUT_STRING);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, pRequestInfo->body != NULL ? pRequestInfo->body : "");
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, pRequestInfo->bodySize);
+    } else if (pRequestInfo->verb == HTTP_REQUEST_VERB_POST) {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, HTTP_REQUEST_VERB_POST_STRING);
+        if (pRequestInfo->body != NULL) {
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, pRequestInfo->body);
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, pRequestInfo->bodySize);
+        }
+    }
+
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, pHeaderList);
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errorBuffer);
     curl_easy_setopt(curl, CURLOPT_URL, pRequestInfo->url);
@@ -81,7 +93,8 @@ STATUS blockingCurlCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
     }
 
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpStatusCode);
-    CHK_ERR(httpStatusCode == HTTP_STATUS_CODE_OK, STATUS_CURL_PERFORM_FAILED, "Curl call response failed with http status %lu", httpStatusCode);
+    curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url);
+    CHK_ERR(httpStatusCode == HTTP_STATUS_CODE_OK, STATUS_CURL_PERFORM_FAILED, "Curl call to %s failed with http status %lu", url, httpStatusCode);
 
 CleanUp:
 

--- a/src/source/Common/Curl/CurlEc2CredentialProvider.c
+++ b/src/source/Common/Curl/CurlEc2CredentialProvider.c
@@ -1,0 +1,16 @@
+/**
+ * Kinesis Video Producer EC2 IMDS based Credential Provider for libCurl
+ */
+#define LOG_CLASS "CurlEc2CredentialProvider"
+#include "../Include_i.h"
+
+STATUS createCurlEc2CredentialProvider(PAwsCredentialProvider* ppCredentialProvider)
+{
+    return createCurlEc2CredentialProviderWithTime(commonDefaultGetCurrentTimeFunc, 0, ppCredentialProvider);
+}
+
+STATUS createCurlEc2CredentialProviderWithTime(GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData, PAwsCredentialProvider* ppCredentialProvider)
+{
+    return createEc2CredentialProviderWithTime(IMDS_REQUEST_CONNECTION_TIMEOUT, IMDS_REQUEST_COMPLETION_TIMEOUT, getCurrentTimeFn, customData,
+                                               blockingCurlCall, ppCredentialProvider);
+}

--- a/src/source/Common/Curl/CurlEc2CredentialProvider.h
+++ b/src/source/Common/Curl/CurlEc2CredentialProvider.h
@@ -1,0 +1,14 @@
+
+#ifndef __KINESIS_VIDEO_CURL_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__
+#define __KINESIS_VIDEO_CURL_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_CURL_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__ */

--- a/src/source/Common/Ec2CredentialProvider.c
+++ b/src/source/Common/Ec2CredentialProvider.c
@@ -1,0 +1,307 @@
+/**
+ * Kinesis Video Producer EC2 IMDS based Credential Provider
+ */
+#define LOG_CLASS "Ec2CredentialProvider"
+#include "Include_i.h"
+
+STATUS createEc2CredentialProviderWithTime(UINT64 connectionTimeout, UINT64 completionTimeout, GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData,
+                                           BlockingServiceCallFunc serviceCallFn, PAwsCredentialProvider* ppCredentialProvider)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PEc2CredentialProvider pEc2CredentialProvider = NULL;
+
+    CHK(ppCredentialProvider != NULL && serviceCallFn != NULL, STATUS_NULL_ARG);
+
+    pEc2CredentialProvider = (PEc2CredentialProvider) MEMCALLOC(1, SIZEOF(Ec2CredentialProvider));
+    CHK(pEc2CredentialProvider != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pEc2CredentialProvider->credentialProvider.getCredentialsFn = getEc2Credentials;
+
+    pEc2CredentialProvider->getCurrentTimeFn = (getCurrentTimeFn == NULL) ? commonDefaultGetCurrentTimeFunc : getCurrentTimeFn;
+    pEc2CredentialProvider->customData = customData;
+
+    if (completionTimeout < connectionTimeout) {
+        connectionTimeout = IMDS_REQUEST_CONNECTION_TIMEOUT;
+        completionTimeout = IMDS_REQUEST_COMPLETION_TIMEOUT;
+    }
+    if (connectionTimeout == 0) {
+        connectionTimeout = IMDS_REQUEST_CONNECTION_TIMEOUT;
+    }
+    if (completionTimeout == 0) {
+        completionTimeout = IMDS_REQUEST_COMPLETION_TIMEOUT;
+    }
+    pEc2CredentialProvider->connectionTimeout = connectionTimeout;
+    pEc2CredentialProvider->completionTimeout = completionTimeout;
+
+    pEc2CredentialProvider->serviceCallFn = serviceCallFn;
+    pEc2CredentialProvider->imdsTokenExpiration = 0;
+
+    CHK_STATUS(ec2CredentialHandler(pEc2CredentialProvider));
+
+CleanUp:
+
+    if (STATUS_FAILED(retStatus)) {
+        freeEc2CredentialProvider((PAwsCredentialProvider*) &pEc2CredentialProvider);
+        pEc2CredentialProvider = NULL;
+    }
+
+    if (ppCredentialProvider != NULL) {
+        *ppCredentialProvider = (PAwsCredentialProvider) pEc2CredentialProvider;
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS freeEc2CredentialProvider(PAwsCredentialProvider* ppCredentialProvider)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PEc2CredentialProvider pEc2CredentialProvider = NULL;
+
+    CHK(ppCredentialProvider != NULL, STATUS_NULL_ARG);
+
+    pEc2CredentialProvider = (PEc2CredentialProvider) *ppCredentialProvider;
+
+    // Call is idempotent
+    CHK(pEc2CredentialProvider != NULL, retStatus);
+
+    // Release the underlying AWS credentials object
+    freeAwsCredentials(&pEc2CredentialProvider->pAwsCredentials);
+
+    // Release the object
+    MEMFREE(pEc2CredentialProvider);
+
+    // Set the pointer to NULL
+    *ppCredentialProvider = NULL;
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS getEc2Credentials(PAwsCredentialProvider pCredentialProvider, PAwsCredentials* ppAwsCredentials)
+{
+    ENTERS();
+
+    STATUS retStatus = STATUS_SUCCESS;
+    PEc2CredentialProvider pEc2CredentialProvider = (PEc2CredentialProvider) pCredentialProvider;
+
+    CHK(pEc2CredentialProvider != NULL && ppAwsCredentials != NULL, STATUS_NULL_ARG);
+
+    CHK_STATUS(ec2CredentialHandler(pEc2CredentialProvider));
+
+    *ppAwsCredentials = pEc2CredentialProvider->pAwsCredentials;
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS ec2FetchImdsToken(PEc2CredentialProvider pEc2CredentialProvider)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 currentTime;
+    CHAR tokenUrl[MAX_URI_CHAR_LEN + 1];
+    PRequestInfo pRequestInfo = NULL;
+    CallInfo callInfo;
+
+    MEMSET(&callInfo, 0x00, SIZEOF(CallInfo));
+
+    CHK(pEc2CredentialProvider != NULL, STATUS_NULL_ARG);
+
+    currentTime = pEc2CredentialProvider->getCurrentTimeFn(pEc2CredentialProvider->customData);
+
+    // Check if existing token is still valid
+    CHK(pEc2CredentialProvider->imdsTokenExpiration == 0 || currentTime >= pEc2CredentialProvider->imdsTokenExpiration, retStatus);
+
+    SNPRINTF(tokenUrl, MAX_URI_CHAR_LEN, "http://%s%s", IMDS_DEFAULT_ENDPOINT, IMDS_TOKEN_PATH);
+
+    CHK_STATUS(createRequestInfo(tokenUrl, NULL, DEFAULT_AWS_REGION, NULL, NULL, NULL, SSL_CERTIFICATE_TYPE_NOT_SPECIFIED, DEFAULT_USER_AGENT_NAME,
+                                 pEc2CredentialProvider->connectionTimeout, pEc2CredentialProvider->completionTimeout, DEFAULT_LOW_SPEED_LIMIT,
+                                 DEFAULT_LOW_SPEED_TIME_LIMIT, NULL, &pRequestInfo));
+
+    pRequestInfo->verb = HTTP_REQUEST_VERB_PUT;
+
+    CHK_STATUS(setRequestHeader(pRequestInfo, (PCHAR) IMDS_TOKEN_TTL_HEADER, 0, (PCHAR) IMDS_TOKEN_TTL_SECONDS, 0));
+
+    callInfo.pRequestInfo = pRequestInfo;
+
+    CHK_STATUS(pEc2CredentialProvider->serviceCallFn(pRequestInfo, &callInfo));
+
+    CHK_ERR(callInfo.responseDataLen > 0 && callInfo.responseDataLen <= IMDS_TOKEN_LEN, STATUS_IMDS_TOKEN_FETCH_FAILED,
+            "Failed to fetch IMDSv2 token");
+
+    MEMCPY(pEc2CredentialProvider->imdsToken, callInfo.responseData, callInfo.responseDataLen);
+    pEc2CredentialProvider->imdsToken[callInfo.responseDataLen] = '\0';
+
+    pEc2CredentialProvider->imdsTokenExpiration = currentTime + IMDS_TOKEN_EXPIRATION_DURATION;
+
+CleanUp:
+
+    if (pRequestInfo != NULL) {
+        freeRequestInfo(&pRequestInfo);
+    }
+
+    releaseCallInfo(&callInfo);
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS ec2CredentialHandler(PEc2CredentialProvider pEc2CredentialProvider)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 currentTime;
+    CHAR roleUrl[MAX_URI_CHAR_LEN + 1];
+    CHAR credUrl[MAX_URI_CHAR_LEN + 1];
+    CHAR roleName[IMDS_ROLE_NAME_LEN + 1];
+    PRequestInfo pRequestInfo = NULL;
+    CallInfo callInfo;
+
+    MEMSET(&callInfo, 0x00, SIZEOF(CallInfo));
+
+    CHK(pEc2CredentialProvider != NULL, STATUS_NULL_ARG);
+
+    // Check if cached credentials are still valid
+    currentTime = pEc2CredentialProvider->getCurrentTimeFn(pEc2CredentialProvider->customData);
+    CHK(pEc2CredentialProvider->pAwsCredentials == NULL ||
+            currentTime + IMDS_CREDENTIAL_FETCH_GRACE_PERIOD > pEc2CredentialProvider->pAwsCredentials->expiration,
+        retStatus);
+
+    // Ensure we have a valid IMDSv2 token
+    CHK_STATUS(ec2FetchImdsToken(pEc2CredentialProvider));
+
+    // Step 1: Get the IAM role name
+    SNPRINTF(roleUrl, MAX_URI_CHAR_LEN, "http://%s%s", IMDS_DEFAULT_ENDPOINT, IMDS_ROLE_PATH);
+
+    CHK_STATUS(createRequestInfo(roleUrl, NULL, DEFAULT_AWS_REGION, NULL, NULL, NULL, SSL_CERTIFICATE_TYPE_NOT_SPECIFIED, DEFAULT_USER_AGENT_NAME,
+                                 pEc2CredentialProvider->connectionTimeout, pEc2CredentialProvider->completionTimeout, DEFAULT_LOW_SPEED_LIMIT,
+                                 DEFAULT_LOW_SPEED_TIME_LIMIT, NULL, &pRequestInfo));
+
+    pRequestInfo->verb = HTTP_REQUEST_VERB_GET;
+
+    CHK_STATUS(setRequestHeader(pRequestInfo, (PCHAR) IMDS_TOKEN_HEADER, 0, pEc2CredentialProvider->imdsToken, 0));
+
+    callInfo.pRequestInfo = pRequestInfo;
+
+    CHK_STATUS(pEc2CredentialProvider->serviceCallFn(pRequestInfo, &callInfo));
+
+    CHK_ERR(callInfo.responseDataLen > 0 && callInfo.responseDataLen <= IMDS_ROLE_NAME_LEN, STATUS_IMDS_ROLE_FETCH_FAILED,
+            "Failed to fetch IAM role name from IMDS");
+
+    MEMCPY(roleName, callInfo.responseData, callInfo.responseDataLen);
+    roleName[callInfo.responseDataLen] = '\0';
+
+    freeRequestInfo(&pRequestInfo);
+    pRequestInfo = NULL;
+    releaseCallInfo(&callInfo);
+    MEMSET(&callInfo, 0x00, SIZEOF(CallInfo));
+
+    // Step 2: Get credentials for the role
+    SNPRINTF(credUrl, MAX_URI_CHAR_LEN, "http://%s%s%s", IMDS_DEFAULT_ENDPOINT, IMDS_ROLE_PATH, roleName);
+
+    CHK_STATUS(createRequestInfo(credUrl, NULL, DEFAULT_AWS_REGION, NULL, NULL, NULL, SSL_CERTIFICATE_TYPE_NOT_SPECIFIED, DEFAULT_USER_AGENT_NAME,
+                                 pEc2CredentialProvider->connectionTimeout, pEc2CredentialProvider->completionTimeout, DEFAULT_LOW_SPEED_LIMIT,
+                                 DEFAULT_LOW_SPEED_TIME_LIMIT, NULL, &pRequestInfo));
+
+    pRequestInfo->verb = HTTP_REQUEST_VERB_GET;
+
+    CHK_STATUS(setRequestHeader(pRequestInfo, (PCHAR) IMDS_TOKEN_HEADER, 0, pEc2CredentialProvider->imdsToken, 0));
+
+    callInfo.pRequestInfo = pRequestInfo;
+
+    CHK_STATUS(pEc2CredentialProvider->serviceCallFn(pRequestInfo, &callInfo));
+
+    CHK_STATUS(parseEc2Response(pEc2CredentialProvider, &callInfo));
+
+CleanUp:
+
+    if (STATUS_FAILED(retStatus) && pEc2CredentialProvider != NULL) {
+        pEc2CredentialProvider->imdsTokenExpiration = 0;
+    }
+
+    if (pRequestInfo != NULL) {
+        freeRequestInfo(&pRequestInfo);
+    }
+
+    releaseCallInfo(&callInfo);
+
+    return retStatus;
+}
+
+STATUS parseEc2Response(PEc2CredentialProvider pEc2CredentialProvider, PCallInfo pCallInfo)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    UINT32 i, resultLen, accessKeyIdLen = 0, secretKeyLen = 0, sessionTokenLen = 0, expirationTimestampLen = 0;
+    INT32 tokenCount;
+    jsmn_parser parser;
+    jsmntok_t tokens[MAX_JSON_TOKEN_COUNT];
+    PCHAR accessKeyId = NULL, secretKey = NULL, sessionToken = NULL, expirationTimestamp = NULL, pResponseStr = NULL;
+    UINT64 expiration, currentTime;
+    CHAR expirationTimestampStr[MAX_EXPIRATION_LEN + 1];
+
+    CHK(pEc2CredentialProvider != NULL && pCallInfo != NULL, STATUS_NULL_ARG);
+
+    resultLen = pCallInfo->responseDataLen;
+    CHK_ERR(resultLen > 0, STATUS_IMDS_INVALID_RESPONSE_LENGTH, "IMDS response has a length of 0");
+    pResponseStr = pCallInfo->responseData;
+
+    jsmn_init(&parser);
+    tokenCount = jsmn_parse(&parser, pResponseStr, resultLen, tokens, SIZEOF(tokens) / SIZEOF(jsmntok_t));
+
+    CHK(tokenCount > 1, STATUS_INVALID_API_CALL_RETURN_JSON);
+    CHK(tokens[0].type == JSMN_OBJECT, STATUS_INVALID_API_CALL_RETURN_JSON);
+
+    for (i = 1; i < (UINT32) tokenCount; i++) {
+        if (compareJsonString(pResponseStr, &tokens[i], JSMN_STRING, (PCHAR) "AccessKeyId")) {
+            accessKeyIdLen = (UINT32) (tokens[i + 1].end - tokens[i + 1].start);
+            CHK(accessKeyIdLen <= MAX_ACCESS_KEY_LEN, STATUS_INVALID_API_CALL_RETURN_JSON);
+            accessKeyId = pResponseStr + tokens[i + 1].start;
+            i++;
+        } else if (compareJsonString(pResponseStr, &tokens[i], JSMN_STRING, (PCHAR) "SecretAccessKey")) {
+            secretKeyLen = (UINT32) (tokens[i + 1].end - tokens[i + 1].start);
+            CHK(secretKeyLen <= MAX_SECRET_KEY_LEN, STATUS_INVALID_API_CALL_RETURN_JSON);
+            secretKey = pResponseStr + tokens[i + 1].start;
+            i++;
+        } else if (compareJsonString(pResponseStr, &tokens[i], JSMN_STRING, (PCHAR) "Token")) {
+            sessionTokenLen = (UINT32) (tokens[i + 1].end - tokens[i + 1].start);
+            CHK(sessionTokenLen <= MAX_SESSION_TOKEN_LEN, STATUS_INVALID_API_CALL_RETURN_JSON);
+            sessionToken = pResponseStr + tokens[i + 1].start;
+            i++;
+        } else if (compareJsonString(pResponseStr, &tokens[i], JSMN_STRING, (PCHAR) "Expiration")) {
+            expirationTimestampLen = (UINT32) (tokens[i + 1].end - tokens[i + 1].start);
+            CHK(expirationTimestampLen <= MAX_EXPIRATION_LEN, STATUS_INVALID_API_CALL_RETURN_JSON);
+            expirationTimestamp = pResponseStr + tokens[i + 1].start;
+            MEMCPY(expirationTimestampStr, expirationTimestamp, expirationTimestampLen);
+            expirationTimestampStr[expirationTimestampLen] = '\0';
+            i++;
+        }
+    }
+
+    CHK(accessKeyId != NULL && secretKey != NULL && sessionToken != NULL, STATUS_IMDS_NULL_AWS_CREDS);
+
+    currentTime = pEc2CredentialProvider->getCurrentTimeFn(pEc2CredentialProvider->customData);
+    CHK_STATUS(convertTimestampToEpoch(expirationTimestampStr, currentTime / HUNDREDS_OF_NANOS_IN_A_SECOND, &expiration));
+    DLOGD("EC2 IMDS credential expiration time %" PRIu64, expiration / HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    if (pEc2CredentialProvider->pAwsCredentials != NULL) {
+        freeAwsCredentials(&pEc2CredentialProvider->pAwsCredentials);
+        pEc2CredentialProvider->pAwsCredentials = NULL;
+    }
+
+    CHK_STATUS(createAwsCredentials(accessKeyId, accessKeyIdLen, secretKey, secretKeyLen, sessionToken, sessionTokenLen, expiration,
+                                    &pEc2CredentialProvider->pAwsCredentials));
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}

--- a/src/source/Common/Ec2CredentialProvider.c
+++ b/src/source/Common/Ec2CredentialProvider.c
@@ -134,7 +134,8 @@ STATUS ec2FetchImdsToken(PEc2CredentialProvider pEc2CredentialProvider)
     CHK_STATUS(pEc2CredentialProvider->serviceCallFn(pRequestInfo, &callInfo));
 
     CHK_ERR(callInfo.responseDataLen > 0 && callInfo.responseDataLen <= IMDS_TOKEN_LEN, STATUS_IMDS_TOKEN_FETCH_FAILED,
-            "Failed to fetch IMDSv2 token");
+            "Failed to fetch IMDSv2 session token from %s. Verify that the instance has IMDSv2 enabled and the metadata service is reachable.",
+            tokenUrl);
 
     MEMCPY(pEc2CredentialProvider->imdsToken, callInfo.responseData, callInfo.responseDataLen);
     pEc2CredentialProvider->imdsToken[callInfo.responseDataLen] = '\0';
@@ -174,6 +175,8 @@ STATUS ec2CredentialHandler(PEc2CredentialProvider pEc2CredentialProvider)
             currentTime + IMDS_CREDENTIAL_FETCH_GRACE_PERIOD > pEc2CredentialProvider->pAwsCredentials->expiration,
         retStatus);
 
+    DLOGI("Attempting to fetch EC2 IMDS credentials");
+
     // Ensure we have a valid IMDSv2 token
     CHK_STATUS(ec2FetchImdsToken(pEc2CredentialProvider));
 
@@ -193,7 +196,7 @@ STATUS ec2CredentialHandler(PEc2CredentialProvider pEc2CredentialProvider)
     CHK_STATUS(pEc2CredentialProvider->serviceCallFn(pRequestInfo, &callInfo));
 
     CHK_ERR(callInfo.responseDataLen > 0 && callInfo.responseDataLen <= IMDS_ROLE_NAME_LEN, STATUS_IMDS_ROLE_FETCH_FAILED,
-            "Failed to fetch IAM role name from IMDS");
+            "Failed to fetch IAM role name from IMDS. Verify that an IAM role is attached to the EC2 instance.");
 
     MEMCPY(roleName, callInfo.responseData, callInfo.responseDataLen);
     roleName[callInfo.responseDataLen] = '\0';
@@ -219,6 +222,8 @@ STATUS ec2CredentialHandler(PEc2CredentialProvider pEc2CredentialProvider)
     CHK_STATUS(pEc2CredentialProvider->serviceCallFn(pRequestInfo, &callInfo));
 
     CHK_STATUS(parseEc2Response(pEc2CredentialProvider, &callInfo));
+
+    DLOGI("Successfully fetched EC2 credentials for role %s", roleName);
 
 CleanUp:
 

--- a/src/source/Common/Ec2CredentialProvider.h
+++ b/src/source/Common/Ec2CredentialProvider.h
@@ -1,0 +1,79 @@
+
+#ifndef __KINESIS_VIDEO_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__
+#define __KINESIS_VIDEO_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IMDS_REQUEST_CONNECTION_TIMEOUT (2 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+#define IMDS_REQUEST_COMPLETION_TIMEOUT (4 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+#define IMDS_DEFAULT_ENDPOINT  "169.254.169.254"
+#define IMDS_TOKEN_PATH        "/latest/api/token"
+#define IMDS_ROLE_PATH         "/latest/meta-data/iam/security-credentials/"
+#define IMDS_TOKEN_TTL_HEADER  "X-aws-ec2-metadata-token-ttl-seconds"
+#define IMDS_TOKEN_TTL_SECONDS "21600"
+#define IMDS_TOKEN_HEADER      "X-aws-ec2-metadata-token"
+
+#define IMDS_TOKEN_LEN     (2048)
+#define IMDS_ROLE_NAME_LEN (256)
+
+/**
+ * Grace period for refreshing credentials before they expire
+ */
+#define IMDS_CREDENTIAL_FETCH_GRACE_PERIOD                                                                                                           \
+    (5 * HUNDREDS_OF_NANOS_IN_A_SECOND + MIN_STREAMING_TOKEN_EXPIRATION_DURATION + STREAMING_TOKEN_EXPIRATION_GRACE_PERIOD)
+
+/**
+ * IMDSv2 token validity: 6 hours in 100ns units
+ */
+#define IMDS_TOKEN_EXPIRATION_DURATION (6 * 3600 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+typedef struct __Ec2CredentialProvider Ec2CredentialProvider;
+struct __Ec2CredentialProvider {
+    // First member should be the abstract credential provider
+    AwsCredentialProvider credentialProvider;
+
+    // Current time functionality - optional
+    GetCurrentTimeFunc getCurrentTimeFn;
+
+    // Custom data supplied to time function
+    UINT64 customData;
+
+    // IMDSv2 session token
+    CHAR imdsToken[IMDS_TOKEN_LEN + 1];
+
+    // When the IMDSv2 session token expires (100ns absolute time)
+    UINT64 imdsTokenExpiration;
+
+    UINT64 connectionTimeout;
+
+    UINT64 completionTimeout;
+
+    // Cached AWS credentials
+    PAwsCredentials pAwsCredentials;
+
+    // Service call functionality
+    BlockingServiceCallFunc serviceCallFn;
+};
+typedef struct __Ec2CredentialProvider* PEc2CredentialProvider;
+
+////////////////////////////////////////////////////////////////////////
+// Callback function implementations
+////////////////////////////////////////////////////////////////////////
+STATUS createEc2CredentialProviderWithTime(UINT64, UINT64, GetCurrentTimeFunc, UINT64, BlockingServiceCallFunc, PAwsCredentialProvider*);
+STATUS freeEc2CredentialProvider(PAwsCredentialProvider*);
+STATUS getEc2Credentials(PAwsCredentialProvider, PAwsCredentials*);
+
+// Internal functions
+STATUS ec2CredentialHandler(PEc2CredentialProvider);
+STATUS ec2FetchImdsToken(PEc2CredentialProvider);
+STATUS parseEc2Response(PEc2CredentialProvider, PCallInfo);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__ */

--- a/src/source/Common/Include_i.h
+++ b/src/source/Common/Include_i.h
@@ -74,6 +74,7 @@ typedef struct __CRYPTO_dynlock_value* PCRYPTO_dynlock_value;
 #if defined(KVS_BUILD_WITH_LWS)
 #include "Lws/LwsCall.h"
 #include "Lws/LwsIotCredentialProvider.h"
+#include "Lws/LwsEc2CredentialProvider.h"
 #endif
 
 #include "IotCredentialProvider.h"

--- a/src/source/Common/Include_i.h
+++ b/src/source/Common/Include_i.h
@@ -69,6 +69,7 @@ typedef struct __CRYPTO_dynlock_value* PCRYPTO_dynlock_value;
 #if defined(KVS_BUILD_WITH_CURL)
 #include "Curl/CurlCall.h"
 #include "Curl/CurlIotCredentialProvider.h"
+#include "Curl/CurlEc2CredentialProvider.h"
 #endif
 #if defined(KVS_BUILD_WITH_LWS)
 #include "Lws/LwsCall.h"
@@ -76,6 +77,7 @@ typedef struct __CRYPTO_dynlock_value* PCRYPTO_dynlock_value;
 #endif
 
 #include "IotCredentialProvider.h"
+#include "Ec2CredentialProvider.h"
 #include "AwsV4Signer.h"
 #include "Util.h"
 #include "RequestInfo.h"

--- a/src/source/Common/Lws/LwsCall.c
+++ b/src/source/Common/Lws/LwsCall.c
@@ -16,8 +16,11 @@ STATUS blockingLwsCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
     struct lws* clientLws = NULL;
     volatile INT32 retVal = 0;
     struct lws_protocols lwsProtocols[2];
+    BOOL useSsl;
 
     CHK(pRequestInfo != NULL && pCallInfo != NULL, STATUS_NULL_ARG);
+
+    useSsl = STRNCMP(pRequestInfo->url, "http://", 7) != 0;
 
     // Prepare the signaling channel protocols array
     MEMSET(lwsProtocols, 0x00, SIZEOF(lwsProtocols));
@@ -28,24 +31,26 @@ STATUS blockingLwsCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
 
     // Prepare the LWS context
     MEMSET(&creationInfo, 0x00, SIZEOF(struct lws_context_creation_info));
-    creationInfo.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+    creationInfo.options = useSsl ? LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT : 0;
     creationInfo.port = CONTEXT_PORT_NO_LISTEN;
     creationInfo.protocols = lwsProtocols;
     creationInfo.timeout_secs = pRequestInfo->completionTimeout / HUNDREDS_OF_NANOS_IN_A_SECOND;
     creationInfo.gid = -1;
     creationInfo.uid = -1;
     creationInfo.fd_limit_per_thread = 1 + 1 + 1;
-    creationInfo.client_ssl_ca_filepath = pRequestInfo->certPath;
-    creationInfo.client_ssl_cert_filepath = pRequestInfo->sslCertPath;
-    creationInfo.client_ssl_private_key_filepath = pRequestInfo->sslPrivateKeyPath;
+    if (useSsl) {
+        creationInfo.client_ssl_ca_filepath = pRequestInfo->certPath;
+        creationInfo.client_ssl_cert_filepath = pRequestInfo->sslCertPath;
+        creationInfo.client_ssl_private_key_filepath = pRequestInfo->sslPrivateKeyPath;
+    }
 
     CHK(NULL != (lwsContext = lws_create_context(&creationInfo)), STATUS_IOT_CREATE_LWS_CONTEXT_FAILED);
 
     // Execute the LWS REST call
     MEMSET(&connectInfo, 0x00, SIZEOF(struct lws_client_connect_info));
     connectInfo.context = lwsContext;
-    connectInfo.ssl_connection = LCCSCF_USE_SSL;
-    connectInfo.port = DEFAULT_SSL_PORT_NUMBER;
+    connectInfo.ssl_connection = useSsl ? LCCSCF_USE_SSL : 0;
+    connectInfo.port = useSsl ? DEFAULT_SSL_PORT_NUMBER : 80;
 
     CHK_STATUS(getRequestHost(pRequestInfo->url, &pHostStart, &pHostEnd));
 
@@ -59,7 +64,17 @@ STATUS blockingLwsCall(PRequestInfo pRequestInfo, PCallInfo pCallInfo)
     connectInfo.address = pHostStart;
     connectInfo.path = path;
     connectInfo.host = connectInfo.address;
-    connectInfo.method = HTTP_REQUEST_VERB_GET_STRING;
+    switch (pRequestInfo->verb) {
+        case HTTP_REQUEST_VERB_PUT:
+            connectInfo.method = HTTP_REQUEST_VERB_PUT_STRING;
+            break;
+        case HTTP_REQUEST_VERB_POST:
+            connectInfo.method = HTTP_REQUEST_VERB_POST_STRING;
+            break;
+        default:
+            connectInfo.method = HTTP_REQUEST_VERB_GET_STRING;
+            break;
+    }
     connectInfo.protocol = lwsProtocols[0].name;
     connectInfo.pwsi = &clientLws;
 

--- a/src/source/Common/Lws/LwsEc2CredentialProvider.c
+++ b/src/source/Common/Lws/LwsEc2CredentialProvider.c
@@ -1,0 +1,16 @@
+/**
+ * Kinesis Video Producer EC2 IMDS based Credential Provider for libWebSockets
+ */
+#define LOG_CLASS "LwsEc2CredentialProvider"
+#include "../Include_i.h"
+
+STATUS createLwsEc2CredentialProvider(PAwsCredentialProvider* ppCredentialProvider)
+{
+    return createLwsEc2CredentialProviderWithTime(commonDefaultGetCurrentTimeFunc, 0, ppCredentialProvider);
+}
+
+STATUS createLwsEc2CredentialProviderWithTime(GetCurrentTimeFunc getCurrentTimeFn, UINT64 customData, PAwsCredentialProvider* ppCredentialProvider)
+{
+    return createEc2CredentialProviderWithTime(IMDS_REQUEST_CONNECTION_TIMEOUT, IMDS_REQUEST_COMPLETION_TIMEOUT, getCurrentTimeFn, customData,
+                                               blockingLwsCall, ppCredentialProvider);
+}

--- a/src/source/Common/Lws/LwsEc2CredentialProvider.h
+++ b/src/source/Common/Lws/LwsEc2CredentialProvider.h
@@ -1,0 +1,14 @@
+
+#ifndef __KINESIS_VIDEO_LWS_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__
+#define __KINESIS_VIDEO_LWS_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_LWS_EC2_CREDENTIAL_PROVIDER_INCLUDE_I__ */

--- a/src/source/Ec2AuthCallback.c
+++ b/src/source/Ec2AuthCallback.c
@@ -1,0 +1,150 @@
+/**
+ * Kinesis Video Producer EC2 IMDS Auth Callback
+ */
+#define LOG_CLASS "Ec2AuthCallbacks"
+#include "Include_i.h"
+
+STATUS createEc2AuthCallbacks(PClientCallbacks pCallbacksProvider, PAuthCallbacks* ppEc2AuthCallbacks)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    PEc2AuthCallbacks pEc2AuthCallbacks = NULL;
+
+    CHK(pCallbacksProvider != NULL && ppEc2AuthCallbacks != NULL, STATUS_NULL_ARG);
+
+    pEc2AuthCallbacks = (PEc2AuthCallbacks) MEMCALLOC(1, SIZEOF(Ec2AuthCallbacks));
+    CHK(pEc2AuthCallbacks != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pEc2AuthCallbacks->authCallbacks.version = AUTH_CALLBACKS_CURRENT_VERSION;
+    pEc2AuthCallbacks->authCallbacks.customData = (UINT64) pEc2AuthCallbacks;
+
+    pEc2AuthCallbacks->pCallbacksProvider = (PCallbacksProvider) pCallbacksProvider;
+
+    pEc2AuthCallbacks->authCallbacks.getStreamingTokenFn = getStreamingTokenEc2Func;
+    pEc2AuthCallbacks->authCallbacks.getSecurityTokenFn = getSecurityTokenEc2Func;
+    pEc2AuthCallbacks->authCallbacks.freeAuthCallbacksFn = freeEc2AuthCallbacksFunc;
+    pEc2AuthCallbacks->authCallbacks.getDeviceCertificateFn = NULL;
+    pEc2AuthCallbacks->authCallbacks.deviceCertToTokenFn = NULL;
+    pEc2AuthCallbacks->authCallbacks.getDeviceFingerprintFn = NULL;
+
+    CHK_STATUS(createCurlEc2CredentialProviderWithTime(pEc2AuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn,
+                                                       pEc2AuthCallbacks->pCallbacksProvider->clientCallbacks.customData,
+                                                       (PAwsCredentialProvider*) &pEc2AuthCallbacks->pCredentialProvider));
+
+    CHK_STATUS(addAuthCallbacks(pCallbacksProvider, (PAuthCallbacks) pEc2AuthCallbacks));
+
+CleanUp:
+
+    if (STATUS_FAILED(retStatus)) {
+        freeEc2AuthCallbacks((PAuthCallbacks*) &pEc2AuthCallbacks);
+        pEc2AuthCallbacks = NULL;
+    }
+
+    if (ppEc2AuthCallbacks != NULL) {
+        *ppEc2AuthCallbacks = (PAuthCallbacks) pEc2AuthCallbacks;
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS freeEc2AuthCallbacks(PAuthCallbacks* ppEc2AuthCallbacks)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    PEc2AuthCallbacks pEc2AuthCallbacks = NULL;
+
+    CHK(ppEc2AuthCallbacks != NULL, STATUS_NULL_ARG);
+
+    pEc2AuthCallbacks = (PEc2AuthCallbacks) *ppEc2AuthCallbacks;
+
+    // Call is idempotent
+    CHK(pEc2AuthCallbacks != NULL, retStatus);
+
+    // Release the underlying AWS credentials provider object
+    freeEc2CredentialProvider((PAwsCredentialProvider*) &pEc2AuthCallbacks->pCredentialProvider);
+
+    // Release the object
+    MEMFREE(pEc2AuthCallbacks);
+
+    // Set the pointer to NULL
+    *ppEc2AuthCallbacks = NULL;
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS freeEc2AuthCallbacksFunc(PUINT64 customData)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PEc2AuthCallbacks pAuthCallbacks;
+
+    CHK(customData != NULL, STATUS_NULL_ARG);
+    pAuthCallbacks = (PEc2AuthCallbacks) *customData;
+    CHK_STATUS(freeEc2AuthCallbacks((PAuthCallbacks*) &pAuthCallbacks));
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS getStreamingTokenEc2Func(UINT64 customData, PCHAR streamName, STREAM_ACCESS_MODE accessMode, PServiceCallContext pServiceCallContext)
+{
+    UNUSED_PARAM(streamName);
+    UNUSED_PARAM(accessMode);
+
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PAwsCredentials pAwsCredentials = NULL;
+    PAwsCredentialProvider pCredentialProvider;
+    PCallbacksProvider pCallbacksProvider = NULL;
+    PEc2AuthCallbacks pEc2AuthCallbacks = (PEc2AuthCallbacks) customData;
+
+    CHK(pEc2AuthCallbacks != NULL && pServiceCallContext != NULL, STATUS_NULL_ARG);
+
+    pCallbacksProvider = pEc2AuthCallbacks->pCallbacksProvider;
+    pCredentialProvider = (PAwsCredentialProvider) pEc2AuthCallbacks->pCredentialProvider;
+    CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));
+
+    CHK_STATUS(getStreamingTokenResultEvent(pServiceCallContext->customData, SERVICE_CALL_RESULT_OK, (PBYTE) pAwsCredentials, pAwsCredentials->size,
+                                            pAwsCredentials->expiration));
+
+CleanUp:
+
+    if (STATUS_FAILED(retStatus) && pServiceCallContext != NULL) {
+        getStreamingTokenResultEvent(pServiceCallContext->customData, SERVICE_CALL_UNKNOWN, NULL, 0, 0);
+        notifyCallResult(pCallbacksProvider, retStatus, pServiceCallContext->customData);
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS getSecurityTokenEc2Func(UINT64 customData, PBYTE* ppBuffer, PUINT32 pSize, PUINT64 pExpiration)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PAwsCredentials pAwsCredentials;
+    PAwsCredentialProvider pCredentialProvider;
+
+    PEc2AuthCallbacks pEc2AuthCallbacks = (PEc2AuthCallbacks) customData;
+    CHK(pEc2AuthCallbacks != NULL && ppBuffer != NULL && pSize != NULL && pExpiration != NULL, STATUS_NULL_ARG);
+
+    pCredentialProvider = (PAwsCredentialProvider) pEc2AuthCallbacks->pCredentialProvider;
+    CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));
+
+    *pExpiration = pAwsCredentials->expiration;
+    *pSize = pAwsCredentials->size;
+    *ppBuffer = (PBYTE) pAwsCredentials;
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}

--- a/src/source/Ec2AuthCallback.h
+++ b/src/source/Ec2AuthCallback.h
@@ -1,0 +1,42 @@
+#ifndef __KINESIS_VIDEO_EC2_AUTH_CALLBACKS_INCLUDE_I__
+#define __KINESIS_VIDEO_EC2_AUTH_CALLBACKS_INCLUDE_I__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Forward declarations
+ */
+struct __CallbacksProvider;
+
+typedef struct __Ec2AuthCallbacks Ec2AuthCallbacks;
+
+struct __Ec2AuthCallbacks {
+    // First member should be the Auth callbacks
+    AuthCallbacks authCallbacks;
+
+    // Pointer to EC2 Credential Provider
+    PAwsCredentialProvider pCredentialProvider;
+
+    // Back pointer to the callback provider object
+    PCallbacksProvider pCallbacksProvider;
+};
+
+typedef struct __Ec2AuthCallbacks* PEc2AuthCallbacks;
+
+////////////////////////////////////////////////////////////////////////
+// Callback function implementations
+////////////////////////////////////////////////////////////////////////
+
+// The callback functions
+STATUS getStreamingTokenEc2Func(UINT64, PCHAR, STREAM_ACCESS_MODE, PServiceCallContext);
+STATUS getSecurityTokenEc2Func(UINT64, PBYTE*, PUINT32, PUINT64);
+STATUS freeEc2AuthCallbacksFunc(PUINT64);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_EC2_AUTH_CALLBACKS_INCLUDE_I__ */

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -63,6 +63,7 @@ typedef enum {
 #include "StaticAuthCallbacks.h"
 #include "StreamInfoProvider.h"
 #include "IotAuthCallback.h"
+#include "Ec2AuthCallback.h"
 #include "CredentialProviderAuthCallbacks.h"
 #include "FileLoggerPlatformCallbackProvider.h"
 

--- a/tst/Ec2CredentialProviderTest.cpp
+++ b/tst/Ec2CredentialProviderTest.cpp
@@ -1,0 +1,232 @@
+#include "ProducerTestFixture.h"
+
+// Include Common internal header for access to Ec2CredentialProvider struct and internal functions
+#define KVS_USE_OPENSSL
+#define KVS_BUILD_WITH_CURL
+#include <src/source/Common/Include_i.h>
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+
+class Ec2CredentialProviderTest : public ProducerClientTestBase {};
+
+TEST_F(Ec2CredentialProviderTest, createEc2CredentialProvider_NullArgs)
+{
+    PAwsCredentialProvider pCredentialProvider = NULL;
+
+    // NULL output pointer
+    EXPECT_EQ(STATUS_NULL_ARG, createEc2CredentialProviderWithTime(0, 0, NULL, 0, NULL, NULL));
+
+    // NULL service call function
+    EXPECT_EQ(STATUS_NULL_ARG, createEc2CredentialProviderWithTime(0, 0, commonDefaultGetCurrentTimeFunc, 0, NULL, &pCredentialProvider));
+    EXPECT_EQ(NULL, pCredentialProvider);
+}
+
+TEST_F(Ec2CredentialProviderTest, freeEc2CredentialProvider_NullArgs)
+{
+    PAwsCredentialProvider pNullProvider = NULL;
+
+    EXPECT_EQ(STATUS_NULL_ARG, freeEc2CredentialProvider(NULL));
+
+    // Idempotent free on NULL pointer
+    EXPECT_EQ(STATUS_SUCCESS, freeEc2CredentialProvider(&pNullProvider));
+}
+
+TEST_F(Ec2CredentialProviderTest, parseEc2Response_NullArgs)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, parseEc2Response(NULL, NULL));
+}
+
+TEST_F(Ec2CredentialProviderTest, parseEc2Response_EmptyResponse)
+{
+    Ec2CredentialProvider provider;
+    CallInfo callInfo;
+
+    MEMSET(&provider, 0, SIZEOF(provider));
+    MEMSET(&callInfo, 0, SIZEOF(callInfo));
+    provider.getCurrentTimeFn = commonDefaultGetCurrentTimeFunc;
+
+    callInfo.responseDataLen = 0;
+    callInfo.responseData = NULL;
+
+    EXPECT_EQ(STATUS_IMDS_INVALID_RESPONSE_LENGTH, parseEc2Response(&provider, &callInfo));
+}
+
+TEST_F(Ec2CredentialProviderTest, parseEc2Response_InvalidJson)
+{
+    Ec2CredentialProvider provider;
+    CallInfo callInfo;
+    CHAR invalidJson[] = "not json at all";
+
+    MEMSET(&provider, 0, SIZEOF(provider));
+    MEMSET(&callInfo, 0, SIZEOF(callInfo));
+    provider.getCurrentTimeFn = commonDefaultGetCurrentTimeFunc;
+
+    callInfo.responseData = invalidJson;
+    callInfo.responseDataLen = STRLEN(invalidJson);
+
+    EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, parseEc2Response(&provider, &callInfo));
+}
+
+TEST_F(Ec2CredentialProviderTest, parseEc2Response_MissingFields)
+{
+    Ec2CredentialProvider provider;
+    CallInfo callInfo;
+    CHAR incompleteJson[] = "{"
+                            "\"AccessKeyId\": \"AKIAIOSFODNN7EXAMPLE\","
+                            "\"SecretAccessKey\": \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\","
+                            "\"Expiration\": \"2025-01-01T00:00:00Z\""
+                            "}";
+
+    MEMSET(&provider, 0, SIZEOF(provider));
+    MEMSET(&callInfo, 0, SIZEOF(callInfo));
+    provider.getCurrentTimeFn = commonDefaultGetCurrentTimeFunc;
+
+    callInfo.responseData = incompleteJson;
+    callInfo.responseDataLen = STRLEN(incompleteJson);
+
+    EXPECT_EQ(STATUS_IMDS_NULL_AWS_CREDS, parseEc2Response(&provider, &callInfo));
+}
+
+TEST_F(Ec2CredentialProviderTest, parseEc2Response_ValidResponse)
+{
+    Ec2CredentialProvider provider;
+    CallInfo callInfo;
+    CHAR validJson[] = "{"
+                       "\"Code\": \"Success\","
+                       "\"LastUpdated\": \"2025-01-01T00:00:00Z\","
+                       "\"Type\": \"AWS-HMAC\","
+                       "\"AccessKeyId\": \"AKIAIOSFODNN7EXAMPLE\","
+                       "\"SecretAccessKey\": \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\","
+                       "\"Token\": \"FwoGZXIvYXdzEBYaDCTESTTOKEN\","
+                       "\"Expiration\": \"2200-01-01T00:00:00Z\""
+                       "}";
+
+    MEMSET(&provider, 0, SIZEOF(provider));
+    MEMSET(&callInfo, 0, SIZEOF(callInfo));
+    provider.getCurrentTimeFn = commonDefaultGetCurrentTimeFunc;
+
+    callInfo.responseData = validJson;
+    callInfo.responseDataLen = STRLEN(validJson);
+
+    EXPECT_EQ(STATUS_SUCCESS, parseEc2Response(&provider, &callInfo));
+    EXPECT_TRUE(provider.pAwsCredentials != NULL);
+
+    if (provider.pAwsCredentials != NULL) {
+        EXPECT_EQ(0, STRNCMP(provider.pAwsCredentials->accessKeyId, "AKIAIOSFODNN7EXAMPLE", 20));
+        EXPECT_EQ(0, STRNCMP(provider.pAwsCredentials->secretKey, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", 40));
+        EXPECT_EQ(0, STRNCMP(provider.pAwsCredentials->sessionToken, "FwoGZXIvYXdzEBYaDCTESTTOKEN", 27));
+        EXPECT_TRUE(provider.pAwsCredentials->expiration > 0);
+
+        freeAwsCredentials(&provider.pAwsCredentials);
+    }
+}
+
+TEST_F(Ec2CredentialProviderTest, parseEc2Response_OverwritesExistingCredentials)
+{
+    Ec2CredentialProvider provider;
+    CallInfo callInfo;
+    CHAR validJson[] = "{"
+                       "\"AccessKeyId\": \"AKIANEWKEY\","
+                       "\"SecretAccessKey\": \"NewSecretKey12345\","
+                       "\"Token\": \"NewSessionToken\","
+                       "\"Expiration\": \"2200-06-15T12:30:00Z\""
+                       "}";
+
+    MEMSET(&provider, 0, SIZEOF(provider));
+    MEMSET(&callInfo, 0, SIZEOF(callInfo));
+    provider.getCurrentTimeFn = commonDefaultGetCurrentTimeFunc;
+
+    // Create initial credentials
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAwsCredentials((PCHAR) "OldKey", 0, (PCHAR) "OldSecret", 0, (PCHAR) "OldToken", 0, MAX_UINT64, &provider.pAwsCredentials));
+
+    callInfo.responseData = validJson;
+    callInfo.responseDataLen = STRLEN(validJson);
+
+    EXPECT_EQ(STATUS_SUCCESS, parseEc2Response(&provider, &callInfo));
+    EXPECT_TRUE(provider.pAwsCredentials != NULL);
+
+    if (provider.pAwsCredentials != NULL) {
+        EXPECT_EQ(0, STRNCMP(provider.pAwsCredentials->accessKeyId, "AKIANEWKEY", 10));
+        EXPECT_EQ(0, STRNCMP(provider.pAwsCredentials->secretKey, "NewSecretKey12345", 17));
+        EXPECT_EQ(0, STRNCMP(provider.pAwsCredentials->sessionToken, "NewSessionToken", 15));
+
+        freeAwsCredentials(&provider.pAwsCredentials);
+    }
+}
+
+TEST_F(Ec2CredentialProviderTest, ec2AuthCallbacks_NullArgs)
+{
+    PAuthCallbacks pAuthCallbacks = NULL;
+
+    EXPECT_EQ(STATUS_NULL_ARG, createEc2AuthCallbacks(NULL, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, createEc2AuthCallbacks(NULL, &pAuthCallbacks));
+
+    EXPECT_EQ(STATUS_NULL_ARG, freeEc2AuthCallbacks(NULL));
+
+    // Idempotent free
+    pAuthCallbacks = NULL;
+    EXPECT_EQ(STATUS_SUCCESS, freeEc2AuthCallbacks(&pAuthCallbacks));
+}
+
+TEST_F(Ec2CredentialProviderTest, getEc2Credentials_NullArgs)
+{
+    PAwsCredentials pAwsCredentials = NULL;
+
+    EXPECT_EQ(STATUS_NULL_ARG, getEc2Credentials(NULL, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, getEc2Credentials(NULL, &pAwsCredentials));
+}
+
+TEST_F(Ec2CredentialProviderTest, ec2FetchImdsToken_NullArg)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, ec2FetchImdsToken(NULL));
+}
+
+TEST_F(Ec2CredentialProviderTest, ec2CredentialHandler_NullArg)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, ec2CredentialHandler(NULL));
+}
+
+TEST_F(Ec2CredentialProviderTest, ec2CredentialHandler_CachedCredentialsNotExpired)
+{
+    Ec2CredentialProvider provider;
+    MEMSET(&provider, 0, SIZEOF(provider));
+    provider.getCurrentTimeFn = commonDefaultGetCurrentTimeFunc;
+
+    // Create credentials with far-future expiration
+    EXPECT_EQ(STATUS_SUCCESS,
+              createAwsCredentials((PCHAR) "TestKey", 0, (PCHAR) "TestSecret", 0, (PCHAR) "TestToken", 0, MAX_UINT64, &provider.pAwsCredentials));
+
+    // Should return immediately without fetching (no serviceCallFn needed)
+    EXPECT_EQ(STATUS_SUCCESS, ec2CredentialHandler(&provider));
+
+    // Verify credentials unchanged
+    EXPECT_EQ(0, STRNCMP(provider.pAwsCredentials->accessKeyId, "TestKey", 7));
+
+    freeAwsCredentials(&provider.pAwsCredentials);
+}
+
+TEST_F(Ec2CredentialProviderTest, ec2FetchImdsToken_CachedTokenNotExpired)
+{
+    Ec2CredentialProvider provider;
+    MEMSET(&provider, 0, SIZEOF(provider));
+    provider.getCurrentTimeFn = commonDefaultGetCurrentTimeFunc;
+
+    // Set up a token that's not expired
+    STRCPY(provider.imdsToken, "cached-token-value");
+    provider.imdsTokenExpiration = MAX_UINT64;
+
+    // Should return immediately without making a call
+    EXPECT_EQ(STATUS_SUCCESS, ec2FetchImdsToken(&provider));
+
+    // Verify token unchanged
+    EXPECT_EQ(0, STRCMP(provider.imdsToken, "cached-token-value"));
+}
+
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/99
- https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/discussions/976

*What was changed?*
  - Added EC2 Instance Metadata Service (IMDSv2) credential provider support.
      - Note: Only IMDSv2 is supported; no IMDSv1 fallback.
  - Updated all samples to use a shared credential resolution chain that prefers environment variable credentials and falls back to EC2 instance credentials.
  - Documented the credential configuration order in the README.

*Why was it changed?*
  - The library previously required explicit credential configuration (static, file-based, or IoT certificates). Users running the KVS Producer on EC2 instances with attached IAM roles had no way to automatically retrieve credentials from the instance metadata service, which is the standard credential discovery mechanism for EC2 workloads.

*How was it changed?*
  - Implemented Ec2CredentialProvider following the existing IoT credential provider pattern: struct embedding for polymorphism, BlockingServiceCallFunc for transport abstraction, and lazy credential refresh with grace periods.
  - The IMDSv2 flow performs a PUT to acquire a session token (6-hour TTL), then GET requests to discover the IAM role name and retrieve temporary credentials. Both the token and credentials are cached and refreshed independently
  before expiration. On credential fetch failure, the IMDS token cache is invalidated to force a fresh token on retry. 
  - Added Ec2AuthCallback bridge to integrate the provider into the callbacks system. 
  - Exposed public APIs at three levels: high-level factory (createDefaultCallbacksProviderWithEc2Credentials), mid-level auth callbacks (createEc2AuthCallbacks/freeEc2AuthCallbacks), and low-level provider (createCurlEc2CredentialProvider/createCurlEc2CredentialProviderWithTime/freeEc2CredentialProvider).
  - Added STATUS_IMDS_* error codes and registered them in the retriable error macro.
  - Added createSampleCallbacksProvider helper in samples/Common.c that implements the credential resolution chain (env credentials first, EC2 IMDS fallback) with endpoint override support. All four samples now use this shared helper. 
  - Added credential configuration section to README documenting the resolution order.

*What testing was done for the changes?*
  - Added 14 unit tests covering: null argument validation, JSON response parsing (valid, invalid, missing fields, overwrite), credential caching behavior (skip refresh when not expired), IMDS token caching, and auth callback lifecycle. 
  - All new tests pass. All existing tests pass with no regressions.
  - Full build verified (libraries, samples, and test binary compile without errors or warnings).

Tested on the EC2 and confirm it's working:

```c
export AWS_KVS_LOG_LEVEL=1
./kvsVideoOnlyRealtimeStreamingSample demo-stream

2026-05-21 22:05:16.023 INFO    createSampleCallbacksProvider(): Environment variable credentials not found, using EC2 IMDS credential provider
2026-05-21 22:05:16.023 INFO    determineKvsControlPlaneEndpointType(): Using LEGACY endpoint from environment
2026-05-21 22:05:16.023 DEBUG   createCurlApiCallbacks(): Initializing curl
2026-05-21 22:05:16.025 DEBUG   createCurlApiCallbacks(): Successfully initialized curl
2026-05-21 22:05:16.025 INFO    ec2CredentialHandler(): Attempting to fetch EC2 IMDS credentials
2026-05-21 22:05:16.025 DEBUG   setRequestHeader(): Appending header to request: user-agent -> AWS-SDK-KVS
2026-05-21 22:05:16.025 DEBUG   setRequestHeader(): Appending header to request: X-aws-ec2-metadata-token-ttl-seconds -> 21600
2026-05-21 22:05:16.027 DEBUG   setRequestHeader(): Appending header to request: user-agent -> AWS-SDK-KVS
2026-05-21 22:05:16.027 DEBUG   setRequestHeader(): Appending header to request: X-aws-ec2-metadata-token -> AQAEXXXXXXXXXXX
2026-05-21 22:05:16.028 DEBUG   setRequestHeader(): Appending header to request: user-agent -> AWS-SDK-KVS
2026-05-21 22:05:16.028 DEBUG   setRequestHeader(): Appending header to request: X-aws-ec2-metadata-token -> AQAEXXXXXXXXXXX
2026-05-21 22:05:16.029 VERBOSE convertTimestampToEpoch(): Expiration timestamp conversion into tm structure  126-4-22T4:15:16
2026-05-21 22:05:16.029 DEBUG   convertTimestampToEpoch(): Difference between current time and iot expiration is 22200
2026-05-21 22:05:16.029 DEBUG   parseEc2Response(): EC2 IMDS credential expiration time 1779423316
2026-05-21 22:05:16.029 INFO    ec2CredentialHandler(): Successfully fetched EC2 credentials for role XXXXXXXXXXXXXRole
2026-05-21 22:05:16.029 INFO    createKinesisVideoClient(): Creating Kinesis Video Client
2026-05-21 22:05:16.029 DEBUG   validateDeviceInfo(): DeviceInfo version: 1
2026-05-21 22:05:16.029 DEBUG   validateClientInfo(): ClientInfo version: 3
2026-05-21 22:05:16.029 DEBUG   validateClientCallbacks(): ClientCallbacks version: 0
2026-05-21 22:05:16.029 DEBUG   validateExponentialBackoffConfig(): Validating maxRetryWaitTime
2026-05-21 22:05:16.029 DEBUG   validateExponentialBackoffConfig(): Validating retryFactorTime
2026-05-21 22:05:16.029 DEBUG   validateExponentialBackoffConfig(): Validating minTimeToResetRetryState
2026-05-21 22:05:16.029 DEBUG   validateExponentialBackoffConfig(): Validating jitterType
2026-05-21 22:05:16.029 VERBOSE normalizeExponentialBackoffConfig(): Thread Id [134814923954560]. Exponential backoff retry strategy config - maxRetryCount: [0], maxRetryWaitTime: [100000000], retryFactorTime: [1000000], minTimeToResetRetryState: [900000000], jitterType: [1], jitterFactor: [0], 
2026-05-21 22:05:16.029 DEBUG   resetExponentialBackoffRetryState(): Thread Id [134814923954560]. Resetting Exponential Backoff State. Last retry system time [0], retry count so far [0], Current system time [17794011160299852]
2026-05-21 22:05:16.029 DEBUG   exponentialBackoffRetryStrategyCreate(): Created exponential backoff retry strategy state with provided retry configuration.
2026-05-21 22:05:16.029 INFO    heapInitialize(): Initializing native heap with limit size 20971520, spill ratio 0% and flags 0x00000001
2026-05-21 22:05:16.030 INFO    heapInitialize(): Creating AIV heap.
2026-05-21 22:05:16.030 INFO    heapInitialize(): Heap is initialized OK
2026-05-21 22:05:16.030 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
2026-05-21 22:05:16.030 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000002, Next state: 0x0000000000000010, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
2026-05-21 22:05:16.030 INFO    createDeviceResultEvent(): Create device result event.
2026-05-21 22:05:16.030 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000010, Next state: 0x0000000000000040, Current local state retry count [0], Max local state retry count [0], State transition wait time [0] ms
2026-05-21 22:05:16.030 INFO    createKinesisVideoStream(): Creating Kinesis Video Stream.
2026-05-21 22:05:16.030 DEBUG   validateStreamInfo(): StreamInfo version: 3
2026-05-21 22:05:16.030 INFO    logStreamInfo(): SDK version: a619efeacafb245a5ae3a8b326d259ea0cafd34f
2026-05-21 22:05:16.030 DEBUG   logStreamInfo(): Kinesis Video Stream Info
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Stream name: demo-stream 
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Streaming type: STREAMING_TYPE_REALTIME 
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Content type: video/h264 
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Max latency (100ns): 314500000
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Fragment duration (100ns): 20000000
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Key frame fragmentation: Yes
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Use frame timecodes: Yes
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Absolute frame timecodes: Yes
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Nal adaptation flags: 40
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Average bandwidth (bps): 2097152
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Framerate: 120
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Buffer duration (100ns): 370000000
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Replay duration (100ns): 185000000
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Connection Staleness duration (100ns): 50000000
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Store Pressure Policy: 1
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        View Overflow Policy: 1
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Allow stream creation: Yes
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Segment UUID: NULL
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Frame ordering mode: 0
2026-05-21 22:05:16.030 DEBUG   logStreamInfo(): Track list
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Track id: 1
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Track name: kvs_video_track
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Codec id: V_MPEG4/ISO/AVC
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Track type: TRACK_INFO_TYPE_VIDEO
2026-05-21 22:05:16.030 DEBUG   logStreamInfo():        Track cpd: NULL
2026-05-21 22:05:16.030 VERBOSE stepStateMachine(): [STREAM] State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
2026-05-21 22:05:16.030 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000040, Next state: 0x0000000000000040, Current local state retry count [1], Max local state retry count [0], State transition wait time [0] ms
2026-05-21 22:05:16.030 DEBUG   initializeCurlSession(): Curl resolving dual stack by default
2026-05-21 22:05:16.030 DEBUG   setRequestHeader(): Appending header to request: user-agent -> AWS-PRODUCER-SDK-KVS/1.6.4 GCC/11.4.0 Linux/6.8.0-1055-aws x86_64
2026-05-21 22:05:16.030 VERBOSE createKinesisVideoStreamSync(): Awaiting for the stream to become ready...
2026-05-21 22:05:16.030 DEBUG   setRequestHeader(): Appending header to request: host -> kinesisvideo.us-west-2.amazonaws.com/describeStream
2026-05-21 22:05:16.030 DEBUG   setRequestHeader(): Appending header to request: X-Amz-Date -> 20260521T220516Z
2026-05-21 22:05:16.030 DEBUG   setRequestHeader(): Appending header to request: content-type -> application/json
2026-05-21 22:05:16.030 DEBUG   setRequestHeader(): Appending header to request: content-length -> 32
2026-05-21 22:05:16.032 DEBUG   setRequestHeader(): Appending header to request: Authorization -> AWS4-HMAC-SHA256 Credential=XXXXXXXX/20260521/us-west-2/kinesisvideo/aws4_request, SignedHeaders=host;user-agent;x-amz-date, Signature=XXX
2026-05-21 22:05:16.032 DEBUG   setRequestHeader(): Appending header to request: x-amz-security-token -> IQXXXXXXXXXXXX
2026-05-21 22:05:16.134 INFO    writeHeaderCallback(): RequestId: XXX
2026-05-21 22:05:16.134 VERBOSE postResponseWriteCallback(): postResponseWriteCallback (curl callback) invoked
2026-05-21 22:05:16.134 DEBUG   describeStreamCurlHandler(): [demo-stream] DescribeStream API response: {"StreamInfo":{"CreationTime":1.625157638783E9,"DataRetentionInHours":48,"DeviceName":"android-client-library","IngestionConfiguration":null,"KmsKeyId":"arn:aws:kms:us-west-2:X:alias/aws/kinesisvideo","MediaType":"video/h264","Status":"ACTIVE","StreamARN":"arn:aws:kinesisvideo:us-west-2:X:stream/demo-stream/X","StreamName":"demo-stream","Version":"X"}}
2026-05-21 22:05:16.135 INFO    describeStreamResultEvent(): Describe stream result event.
2026-05-21 22:05:16.135 WARN    describeStreamResult(): [demo-stream] Retention period (1423147008) returned from the DescribeStream call doesn't match the one specified in the StreamInfo: (-1014444032)
2026-05-21 22:05:16.135 VERBOSE stepStateMachine(): [STREAM] State Machine - Current state: 0x0000000000000002, Next state: 0x0000000000000020, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
2026-05-21 22:05:16.135 VERBOSE stepStateMachine(): [CLIENT] State Machine - Current state: 0x0000000000000040, Next state: 0x0000000000000040, Current local state retry count [2], Max local state retry count [0], State transition wait time [0] ms
2026-05-21 22:05:16.135 DEBUG   initializeCurlSession(): Curl resolving dual stack by default
2026-05-21 22:05:16.135 DEBUG   setRequestHeader(): Appending header to request: user-agent -> AWS-PRODUCER-SDK-KVS/1.6.4 GCC/11.4.0 Linux/6.8.0-1055-aws x86_64
2026-05-21 22:05:16.136 DEBUG   setRequestHeader(): Appending header to request: host -> kinesisvideo.us-west-2.amazonaws.com/getDataEndpoint
2026-05-21 22:05:16.136 DEBUG   setRequestHeader(): Appending header to request: X-Amz-Date -> 20260521T220516Z
2026-05-21 22:05:16.136 DEBUG   setRequestHeader(): Appending header to request: content-type -> application/json
2026-05-21 22:05:16.136 DEBUG   setRequestHeader(): Appending header to request: content-length -> 57
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
