### PR TITLE
Dependencies: Add parallel build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           $CC --version
           $CXX --version
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=ON $CMAKE_FLAGS_EXTRA
+          cmake .. -DBUILD_TEST=ON -DPARALLEL_BUILD=ON $CMAKE_FLAGS_EXTRA
           make -j
 
       - name: Configure AWS Credentials
@@ -109,7 +109,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_COMMON_LWS=TRUE
+          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_COMMON_LWS=TRUE -DPARALLEL_BUILD=ON
           make
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -147,7 +147,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE -DPARALLEL_BUILD=ON
           make
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -180,7 +180,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE
+          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE -DBUILD_COMMON_LWS=TRUE -DPARALLEL_BUILD=ON
           make
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -298,7 +298,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=ON ${{ matrix.build-configuration.cmake-args }}
+          cmake .. -DBUILD_TEST=ON -DPARALLEL_BUILD=ON ${{ matrix.build-configuration.cmake-args }}
           make -j
 
       - name: Check libCurl
@@ -355,7 +355,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DPARALLEL_BUILD=ON
           make -j
           file libcproducer.so
 
@@ -381,7 +381,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DPARALLEL_BUILD=ON
           make -j
           file libcproducer.so
 
@@ -410,7 +410,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32
+          cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DPARALLEL_BUILD=ON
           make
           file libcproducer.so
 
@@ -428,7 +428,7 @@ jobs:
       - name: Build Repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_STATIC=ON
+          cmake .. -DBUILD_STATIC=ON -DPARALLEL_BUILD=ON
           make
 
   linux-thread-size-check:
@@ -467,7 +467,7 @@ jobs:
       - name: Build Repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DKVS_DEFAULT_STACK_SIZE=65536
+          cmake .. -DBUILD_TEST=TRUE -DKVS_DEFAULT_STACK_SIZE=65536 -DPARALLEL_BUILD=ON
           make -j$(nproc)
 
       - name: Run tests with expected failure

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -8,6 +8,12 @@ function(fetch_repo lib_name)
     return()
   endif()
 
+  if(WIN32 OR NOT PARALLEL_BUILD)
+    set(PARALLEL_FLAG "")
+  else()
+    set(PARALLEL_FLAG "--parallel")
+  endif()
+
   # anything after lib_name(${ARGN}) are assumed to be arguments passed over to
   # library building cmake.
   set(build_args ${ARGN})
@@ -25,7 +31,7 @@ function(fetch_repo lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CMAKE_COMMAND} --build . ${PARALLEL_FLAG}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${DEPENDENCY_DOWNLOAD_PATH}/lib${lib_name})
   if(result)
@@ -47,6 +53,12 @@ function(build_dependency lib_name)
   if(${index} EQUAL -1)
     message(WARNING "${lib_name} is not supported to build from source")
     return()
+  endif()
+
+  if(WIN32 OR NOT PARALLEL_BUILD)
+    set(PARALLEL_FLAG "")
+  else()
+    set(PARALLEL_FLAG "--parallel")
   endif()
 
   set(lib_file_name ${lib_name})
@@ -86,7 +98,7 @@ function(build_dependency lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build . --parallel
+    COMMAND ${CMAKE_COMMAND} --build . ${PARALLEL_FLAG}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
   if(result)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(BUILD_OPENSSL_PLATFORM "If buildng OpenSSL what is the target platform" O
 option(LOCAL_OPENSSL_BUILD "Whether or not to use local OpenSSL build" OFF)
 option(CONSTRAINED_DEVICE "Change pthread stack size" OFF)
 option(KVS_ENABLE_VERBOSE_LOGS "Enable ENTERS/LEAVES logs (at LOG_LEVEL_VERBOSE)" OFF)
+option(PARALLEL_BUILD "Build dependencies with parallel flag" OFF)
 
 # Dependency Flags
 option(CURL_USE_FPIC "Compile libcurl with -fPIC flag" ON)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you wish to cross-compile `CC` and `CXX` are respected when building the libr
 You can pass the following options to `cmake ..`.
 
 * `-DBUILD_DEPENDENCIES` -- Whether or not to build depending libraries from source
+* `-DPARALLEL_BUILD` -- Build dependencies with multiple cores. OFF by default. Disabled on Windows.
 * `-DKVS_ENABLE_VERBOSE_LOGS` -- Build with `ENTERS()` and `LEAVES()` logs enabled, which are `LOG_LEVEL_VERBOSE`. Default is OFF.
 * `-DBUILD_TEST=TRUE` -- Build unit/integration tests, may be useful for confirm support for your device. `./tst/producer_test`
 * `-DCODE_COVERAGE` --  Enable coverage reporting


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
  - Added a PARALLEL_BUILD CMake option (default OFF) that controls whether dependencies are built with the `--parallel` flag.
  - Enabled PARALLEL_BUILD in all CI workflow cmake invocations.
  - Documented the new flag in the README.

*Why was it changed?*
  - Improve build speed when building dependencies from source. Previously build_dependency had --parallel unconditionally hardcoded, but fetch_repo had no parallel support. This  change makes the behavior consistent, controllable, and disabled by default since some build systems are unstable with parallel builds.

*How was it changed?*
  - CMakeLists.txt: Added option(PARALLEL_BUILD "Build dependencies with parallel flag" OFF)
  - CMake/Utilities.cmake: Both fetch_repo and build_dependency now check if(WIN32 OR NOT PARALLEL_BUILD) to conditionally set --parallel on cmake --build commands. Removed the  previously hardcoded --parallel in build_dependency.
  - .github/workflows/ci.yml: Added -DPARALLEL_BUILD=ON to all cmake invocations.
  - README.md: Added documentation for the new flag.

*What testing was done for the changes?*
- CI/CD should confirm the changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
