### PR TITLE
Add LOCAL_KVSPIC_PATH Cmake var to use local kvs-pic dependency repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,24 +206,34 @@ find_package(PkgConfig REQUIRED)
 
 ############# Check system for kvspic #############
 
-pkg_check_modules(KVSPIC libkvspicUtils)
-if(KVSPIC_FOUND)
-  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${KVSPIC_INCLUDE_DIRS})
-  link_directories(${KVSPIC_LIBRARY_DIRS})
-else()
-  ############# fetch repos that we need do add_subdirectory ############
-  # repos that we will build using add_subdirectory will be stored in this path
-  set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
-  set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
-  if (PIC_VERSION_OVERRIDE)
-      set(BUILD_ARGS ${BUILD_ARGS} -DPIC_VERSION_OVERRIDE=${PIC_VERSION_OVERRIDE})
+# Local development override: point to your local kvspic checkout
+set(LOCAL_KVSPIC_PATH "" CACHE PATH "Path to local KVS PIC SDK (skips git fetch when set)")
+
+if(LOCAL_KVSPIC_PATH)
+  message(STATUS "Using LOCAL KVS PIC SDK at: ${LOCAL_KVSPIC_PATH}")
+  if(NOT EXISTS ${LOCAL_KVSPIC_PATH}/CMakeLists.txt)
+    message(FATAL_ERROR "LOCAL_KVSPIC_PATH does not contain a CMakeLists.txt: ${LOCAL_KVSPIC_PATH}")
   endif()
-  fetch_repo(kvspic ${BUILD_ARGS})
-  add_subdirectory("${DEPENDENCY_DOWNLOAD_PATH}/libkvspic/kvspic-src")
+  add_subdirectory(${LOCAL_KVSPIC_PATH} ${CMAKE_CURRENT_BINARY_DIR}/kvspic-build)
   file(GLOB PIC_HEADERS "${pic_project_SOURCE_DIR}/src/*/include")
   include_directories("${PIC_HEADERS}")
+else()
+  pkg_check_modules(KVSPIC libkvspicUtils)
+  if(KVSPIC_FOUND)
+    set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${KVSPIC_INCLUDE_DIRS})
+    link_directories(${KVSPIC_LIBRARY_DIRS})
+  else()
+    ############# fetch repos that we need do add_subdirectory ############
+    # repos that we will build using add_subdirectory will be stored in this path
+    set(DEPENDENCY_DOWNLOAD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/dependency)
+    set(BUILD_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+    fetch_repo(kvspic ${BUILD_ARGS})
+    add_subdirectory("${DEPENDENCY_DOWNLOAD_PATH}/libkvspic/kvspic-src")
+    file(GLOB PIC_HEADERS "${pic_project_SOURCE_DIR}/src/*/include")
+    include_directories("${PIC_HEADERS}")
 
-  ############# fetch repos that we need do add_subdirectory done ############
+    ############# fetch repos that we need do add_subdirectory done ############
+  endif()
 endif()
 
 ############# Check system for kvspic done #############

--- a/README.md
+++ b/README.md
@@ -244,6 +244,27 @@ You can do `export KVS_DEBUG_DUMP_DATA_FILE_DIR=/path/to/directory` before strea
 
 To check the frame timestamps submitted to the SDK, enable VERBOSE log level. The PIC library will log the timestamps of each frame submitted.
 
+## Local Development with Dependency Overrides
+
+When developing changes across the SDK stack (C Producer → PIC), you can point the build to a local PIC checkout instead of fetching from GitHub. This avoids the git-fetch cycle and lets you test PIC changes immediately.
+
+### CMake Variable
+
+| Variable | Description |
+|----------|-------------|
+| `LOCAL_KVSPIC_PATH` | Path to a local [KVS PIC](https://github.com/awslabs/amazon-kinesis-video-streams-pic) checkout |
+
+### Usage
+
+```bash
+# Build C Producer using local PIC
+mkdir -p build && cd build
+cmake .. -DLOCAL_KVSPIC_PATH=/path/to/amazon-kinesis-video-streams-pic
+make
+```
+
+When `LOCAL_KVSPIC_PATH` is set, the build uses `add_subdirectory` to include PIC directly from your local path instead of fetching it from GitHub or using a system-installed version. Changes in PIC source files are picked up on the next `make` without re-running `cmake`.
+
 ## Development
 The repository is using `develop` branch as the aggregation and all of the feature development is done in appropriate feature branches. The PRs (Pull Requests) are cut on a feature branch and once approved with all the checks passed they can be merged by a click of a button on the PR tool. The master branch should always be build-able and all the tests should be passing. We are welcoming any contribution to the code base. The master branch contains our most recent release cycle from `develop`.
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added `LOCAL_KVSPIC_PATH` CMake cache variable for local PIC dependency override
- Added "Local Development with Dependency Overrides" section to README.md documenting usage

*Why was it changed?*
- When developing PIC changes (e.g., state machine fixes, retry logic), developers had to push PIC commits before the C Producer build could pick them up, or make changes in dependency folder which can be lost during a rebuild. This added friction during iterative debugging.
- The `LOCAL_KVSPIC_PATH` flag lets cmake use a local PIC checkout via `add_subdirectory`, skipping both the git fetch and the pkg-config system-installed check.

*How was it changed?*
- `CMakeLists.txt`: Added a `CACHE PATH` variable `LOCAL_KVSPIC_PATH`. When set, PIC is included directly via `add_subdirectory` from the provided path. When unset, the existing behavior (pkg-config check → git fetch fallback) is preserved.
- `README.md`: Added a new section before "Development" documenting the variable, standalone usage, integration with the C++ SDK's `LOCAL_KVSC_PATH`, and a typical workflow.

*What testing was done for the changes?*
- Built with `LOCAL_KVSPIC_PATH` pointing to a local PIC checkout and verified that PIC is compiled from local source
- Built without the variable and verified default behavior (pkg-config / git fetch) is unchanged
- Built from the C++ SDK with both `LOCAL_KVSC_PATH` and `LOCAL_KVSPIC_PATH` and verified the forwarding works end-to-end
- Ran `kvsVideoOnlyRealtimeStreamingSample` successfully after building with local PIC override

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.