### PR TITLE
Use computed backoff time and wait before retrying GetToken auth calls

### DIFF
--- a/src/source/CredentialProviderAuthCallbacks.c
+++ b/src/source/CredentialProviderAuthCallbacks.c
@@ -114,10 +114,19 @@ STATUS getStreamingTokenCredentialProviderFunc(UINT64 customData, PCHAR streamNa
     STATUS retStatus = STATUS_SUCCESS;
     PAwsCredentials pAwsCredentials;
     PAwsCredentialProvider pCredentialProvider;
+    UINT64 currentTime;
 
     PCredentialProviderAuthCallbacks pCredentialProviderAuthCallbacks = (PCredentialProviderAuthCallbacks) customData;
 
     CHK(pCredentialProviderAuthCallbacks != NULL, STATUS_NULL_ARG);
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pServiceCallContext->callAfter != 0) {
+        currentTime = pCredentialProviderAuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn(
+            pCredentialProviderAuthCallbacks->pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
+    }
 
     pCredentialProvider = (PAwsCredentialProvider) pCredentialProviderAuthCallbacks->pCredentialProvider;
     CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));

--- a/src/source/FileAuthCallbacks.c
+++ b/src/source/FileAuthCallbacks.c
@@ -116,10 +116,20 @@ STATUS getStreamingTokenFileFunc(UINT64 customData, PCHAR streamName, STREAM_ACC
     PAwsCredentialProvider pCredentialProvider;
     PCallbacksProvider pCallbacksProvider = NULL;
     PFileAuthCallbacks pFileAuthCallbacks = (PFileAuthCallbacks) customData;
+    UINT64 currentTime;
 
     CHK(pFileAuthCallbacks != NULL && pServiceCallContext != NULL, STATUS_NULL_ARG);
 
     pCallbacksProvider = pFileAuthCallbacks->pCallbacksProvider;
+
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pServiceCallContext->callAfter != 0) {
+        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
+    }
+
     pCredentialProvider = (PAwsCredentialProvider) pFileAuthCallbacks->pCredentialProvider;
     CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));
 

--- a/src/source/IotAuthCallback.c
+++ b/src/source/IotAuthCallback.c
@@ -174,8 +174,18 @@ STATUS getStreamingTokenIotFunc(UINT64 customData, PCHAR streamName, STREAM_ACCE
     PAwsCredentialProvider pCredentialProvider;
     PCallbacksProvider pCallbacksProvider = NULL;
     PIotAuthCallbacks pIotAuthCallbacks = (PIotAuthCallbacks) customData;
+    UINT64 currentTime;
 
     CHK(pIotAuthCallbacks != NULL && pServiceCallContext != NULL, STATUS_NULL_ARG);
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+
+    if (pServiceCallContext->callAfter != 0) {
+        currentTime = pIotAuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn(
+            pIotAuthCallbacks->pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
+    }
 
     pCallbacksProvider = pIotAuthCallbacks->pCallbacksProvider;
     pCredentialProvider = (PAwsCredentialProvider) pIotAuthCallbacks->pCredentialProvider;

--- a/src/source/StaticAuthCallbacks.c
+++ b/src/source/StaticAuthCallbacks.c
@@ -117,10 +117,20 @@ STATUS getStreamingTokenStaticFunc(UINT64 customData, PCHAR streamName, STREAM_A
     STATUS retStatus = STATUS_SUCCESS;
     PAwsCredentials pAwsCredentials;
     PAwsCredentialProvider pCredentialProvider;
+    UINT64 currentTime;
 
     PStaticAuthCallbacks pStaticAuthCallbacks = (PStaticAuthCallbacks) customData;
 
-    CHK(pStaticAuthCallbacks != NULL, STATUS_NULL_ARG);
+    CHK(pStaticAuthCallbacks != NULL && pServiceCallContext != NULL, STATUS_NULL_ARG);
+
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pServiceCallContext->callAfter != 0) {
+        currentTime = pStaticAuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn(
+            pStaticAuthCallbacks->pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
+    }
 
     pCredentialProvider = (PAwsCredentialProvider) pStaticAuthCallbacks->pCredentialProvider;
     CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));


### PR DESCRIPTION
*Issue #, if available:*

- N/A

*What was changed?*

- Added `callAfter` enforcement (backoff sleep) to all four synchronous `getStreamingToken` callback implementations: `IotAuthCallback.c`, `StaticAuthCallbacks.c`, `FileAuthCallbacks.c`, and `CredentialProviderAuthCallbacks.c`.

*Why was it changed?*

- When the PIC state machine retries after a PutMedia failure (e.g., 403, 500, or connection timeout), it computes an exponential backoff wait time via `defaultStreamStateTransitionHook` and passes it to the `GET_TOKEN` (next state) state's execute function as `callAfter`. However, all four synchronous token providers ignored `callAfter` entirely and returned cached credentials instantly without sleeping.
- This meant, a retry cycle like `STOPPED → GET_TOKEN → READY → PUT_STREAM` (in case of missing permissions) ran at full speed with zero delay between attempts, creating a retry storm that hammered the service and exhausted process resources (threads, upload handles).
- HTTP-based handlers (describe, getEndpoint) already honor `callAfter` via `THREAD_SLEEP` in the curl layer. The synchronous credential path was the only gap.
- Max wait time: 16,000 ms + jitter (up to 16 seconds more) = theoretical max ~32 seconds

*How was it changed?*

- In each of the four `getStreamingToken*Func` implementations, added a check before credential fetching:
  ```c
  if (pServiceCallContext->callAfter != 0) {
      currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(...);
      if (currentTime < pServiceCallContext->callAfter) {
          THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
      }
  }
  ```
- This makes the token path respect the same exponential backoff as HTTP-based handlers 
- The `callAfter != 0` guard ensures no sleep on normal (non-error) token refresh calls where `callAfter` is set to the current time.

*What testing was done for the changes?*

- Built successfully with `-DBUILD_TEST=ON`
- Manual test: removed PutMedia permission from IAM role, verified retry attempts are spaced with exponential backoff (visible in logs as increasing intervals between `putStreamCurlHandler` entries)
- Verified normal streaming (no errors) is unaffected — `callAfter` equals current time on success path, so the `if (currentTime < callAfter)` check is false and no sleep occurs
- Verified token rotation during live streaming still works without added latency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
