### PR TITLE
Use actual service call result from response to notify listeners

### DIFF
--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -2275,12 +2275,18 @@ CleanUp:
             kinesisVideoStreamTerminated(streamHandle, uploadHandle, callResult);
         }
 
-        // Bubble the notification to potential listeners
         if (callResult != SERVICE_CALL_RESULT_OK && callResult != SERVICE_CALL_RESULT_NOT_SET) {
-            // notify listeners with actual result from the curl response if service call was successful
-            notifyCallResult(pCallbacksProvider, serviceCallResultCheck(callResult), streamHandle);
+            // Non-retriable, non-recoverable errors (e.g., 403/401 auth failures) are reported
+            // to the application with the actual HTTP error from curl response.
+            // Retriable/recoverable errors (timeouts, 500s, 404s) are handled by PIC's state machine.
+            STATUS callStatus = serviceCallResultCheck(callResult);
+            if (!IS_RETRIABLE_ERROR(callStatus) && !IS_RECOVERABLE_ERROR(callStatus)) {
+                notifyCallResult(pCallbacksProvider, callStatus, streamHandle);
+            } else {
+                notifyCallResult(pCallbacksProvider, retStatus, streamHandle);
+            }
         } else {
-            // notify with general return status of the operation
+            // notify with retStatus in case of internal failures
             notifyCallResult(pCallbacksProvider, retStatus, streamHandle);
         }
     }

--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -2276,7 +2276,13 @@ CleanUp:
         }
 
         // Bubble the notification to potential listeners
-        notifyCallResult(pCallbacksProvider, retStatus, streamHandle);
+        if (callResult != SERVICE_CALL_RESULT_OK && callResult != SERVICE_CALL_RESULT_NOT_SET) {
+            // notify listeners with actual result from the curl response if service call was successful
+            notifyCallResult(pCallbacksProvider, serviceCallResultCheck(callResult), streamHandle);
+        } else {
+            // notify with general return status of the operation
+            notifyCallResult(pCallbacksProvider, retStatus, streamHandle);
+        }
     }
 
     LEAVES();

--- a/tst/ProducerClientFaultInjectionTest.cpp
+++ b/tst/ProducerClientFaultInjectionTest.cpp
@@ -484,6 +484,46 @@ TEST_F(ProducerClientFaultInjectionTest, notAuthorizedPutMediaCall)
     // NOTE: PutStream state has no limit on retries
     EXPECT_LE(SERVICE_CALL_MAX_RETRY_COUNT + 1, mCurlPutMediaCount);
 
+    // Verify streamErrorReportFn was called with the auth error
+    EXPECT_LT(0, mStreamErrorFnCount);
+    EXPECT_EQ(STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR, mLastError);
+
+    freeStreams();
+}
+
+TEST_F(ProducerClientFaultInjectionTest, forbiddenPutMediaCall)
+{
+    createDefaultProducerClient(FALSE);
+
+    mPutMediaStatus = STATUS_NOT_IMPLEMENTED; // Non success status
+    mPutMediaCallResult = SERVICE_CALL_FORBIDDEN;
+
+    EXPECT_EQ(STATUS_SUCCESS, createTestStream(0, STREAMING_TYPE_REALTIME, 20 * HUNDREDS_OF_NANOS_IN_A_SECOND, 60 * HUNDREDS_OF_NANOS_IN_A_SECOND));
+
+    // Induce the putMedia call by putting a frame
+    Frame frame;
+    frame.version = FRAME_CURRENT_VERSION;
+    frame.duration = TEST_FRAME_DURATION;
+    frame.frameData = mFrameBuffer;
+    frame.trackId = DEFAULT_VIDEO_TRACK_ID;
+    MEMSET(frame.frameData, 0x55, mFrameSize);
+    frame.index = 0;
+    frame.decodingTs = frame.presentationTs = GETTIME();
+    frame.size = mFrameSize;
+    frame.flags = FRAME_FLAG_KEY_FRAME;
+    EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(mStreams[0], &frame));
+
+    THREAD_SLEEP(2 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    EXPECT_EQ(0, mCurlCreateStreamCount);
+    EXPECT_EQ(1, mCurlDescribeStreamCount);
+    EXPECT_EQ(1, mCurlTagResourceCount);
+    EXPECT_EQ(1, mCurlGetDataEndpointCount);
+
+    // Verify streamErrorReportFn was called with the auth error (403 maps to same status)
+    EXPECT_LT(0, mStreamErrorFnCount);
+    EXPECT_EQ(STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR, mLastError);
+
     freeStreams();
 }
 


### PR DESCRIPTION
*Issue #, if available:*

- N/A

*What was changed?*

- Fixed `putStreamCurlHandler` in `CurlApiCallbacks.c` to pass the actual HTTP error status to `notifyCallResult` instead of `retStatus` (which will always be `STATUS_SUCCESS` in case curl request went through).
- Only non-retriable and non-recoverable errors are notified, retriable/recoverable errors (timeouts, 500s, connection staleness) remain silent as the state machine handles them.
- Added `forbiddenPutMediaCall` test case to `ProducerClientFaultInjectionTest`.
- Added `streamErrorReportFn` assertions to existing `notAuthorizedPutMediaCall` test.

*Why was it changed?*

- When PutMedia returns a non-200 HTTP response (e.g., 403 Forbidden, 401 Not Authorized), `putStreamCurlHandler` called `notifyCallResult(pCallbacksProvider, retStatus, streamHandle)`. However, `retStatus` was `STATUS_SUCCESS` because the curl HTTP exchange itself completed successfully but returned an error response. This caused `notifyCallResult` to early-return without invoking `streamErrorReportFn`, so the listener application never learned about the error.
- Other curl handlers (describe, create, getEndpoint, tagResource) don't have this problem because they already capture the curl call's result into `retStatus`. PutStream is unique as it's a long-running async connection where the error arrives after the initial setup succeeded.

*How was it changed?*

- In `putStreamCurlHandler`'s CleanUp section, replaced:
  ```c
  notifyCallResult(pCallbacksProvider, retStatus, streamHandle);
  ```
  with:
  ```c
  if (callResult != SERVICE_CALL_RESULT_OK && callResult != SERVICE_CALL_RESULT_NOT_SET) {
      STATUS callStatus = serviceCallResultCheck(callResult);
      if (!IS_RETRIABLE_ERROR(callStatus) && !IS_RECOVERABLE_ERROR(callStatus)) {
          notifyCallResult(pCallbacksProvider, callStatus, streamHandle);
      }
  } else {
      notifyCallResult(pCallbacksProvider, retStatus, streamHandle);
  }
  ```
- This converts the HTTP callResult (e.g., 403) to the corresponding STATUS code (`STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR`) and passes it to `notifyCallResult`, which then fires `streamErrorReportFn` through the aggregate callback chain.
- Retriable/recoverable errors (timeouts, 500s, staleness) are filtered out via `IS_RETRIABLE_ERROR` and `IS_RECOVERABLE_ERROR` macros as these errors are handled silently by PIC's state machine and don't need application notification (behavior unchanged).
- The `else` path preserves original behavior: if `callResult` is OK/NOT_SET but `retStatus` is a failure (internal error), the application still gets notified.
- Aftermath: The `ContinuousRetryStreamErrorReportHandler` passes through auth errors (returns SUCCESS without spawning a reset), so the application's registered handler receives the error and can act on it.

*What testing was done for the changes?*

- Added `EXPECT_LT(0, mStreamErrorFnCount)` and `EXPECT_EQ(STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR, mLastError)` to existing `notAuthorizedPutMediaCall` fault injection test.
- Added new `forbiddenPutMediaCall` test that injects `SERVICE_CALL_FORBIDDEN` (403) and verifies `streamErrorReportFn` fires with the correct status.
- Verified other tests (invalidArgPutMediaCall, networkTimeoutPutMediaCall, curl_timeout_idling_force_ack) still pass — retriable/recoverable errors do not trigger notification.
- Manual e2e test: removed PutMedia permission from IAM role, confirmed `streamErrorReportFn` is called.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.