### PR TITLE
map additional transport-level curl errors to network timeout status …

### DIFF
--- a/src/source/Response.c
+++ b/src/source/Response.c
@@ -393,6 +393,9 @@ SERVICE_CALL_RESULT getServiceCallResultFromCurlStatus(CURLcode curlStatus)
         case CURLE_UNSUPPORTED_PROTOCOL:
             return SERVICE_CALL_INVALID_ARG;
         case CURLE_OPERATION_TIMEDOUT:
+        case CURLE_PARTIAL_FILE:
+        case CURLE_COULDNT_RESOLVE_HOST:
+        case CURLE_COULDNT_CONNECT:
             return SERVICE_CALL_NETWORK_CONNECTION_TIMEOUT;
         case CURLE_SSL_CERTPROBLEM:
         case CURLE_SSL_CACERT:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
- Added granular curl error code mappings in `getServiceCallResultFromCurlStatus` (`src/source/Response.c`) so that transport-level connection failures are classified as `SERVICE_CALL_NETWORK_CONNECTION_TIMEOUT` rather than `SERVICE_CALL_UNKNOWN`.

*Why was it changed?*
- When a network outage kills the PutMedia connection, curl reports errors like `CURLE_PARTIAL_FILE` (transfer closed unexpectedly), `CURLE_COULDNT_RESOLVE_HOST` (DNS failure), or `CURLE_COULDNT_CONNECT`. Previously these all fell through to `SERVICE_CALL_UNKNOWN`, which routes the PIC stream state machine through DescribeStream, a control-plane call with a finite retry limit (5). Since DescribeStream also cannot succeed without network connectivity, it exhausts retries and triggers a full stream reset that discards all buffered video.
- These calls correctly belong in the category `SERVICE_CALL_NETWORK_CONNECTION_TIMEOUT`. By mapping these errors to `SERVICE_CALL_NETWORK_CONNECTION_TIMEOUT`, the state machine takes the existing timeout recovery path (`STOPPED → READY → PUT_STREAM`) which retries PutMedia with exponential backoff indefinitely, preserves the content buffer, and avoids unnecessary control-plane calls while the network is down. Once connectivity returns, the SDK reconnects and uploads all buffered content.

*How was it changed?*
- Added `CURLE_PARTIAL_FILE`, `CURLE_COULDNT_RESOLVE_HOST`, and `CURLE_COULDNT_CONNECT` as additional cases mapping to `SERVICE_CALL_NETWORK_CONNECTION_TIMEOUT` in the switch statement in `getServiceCallResultFromCurlStatus()`.

*What testing was done for the changes?*
- Reproduced the customer's scenario locally (blocked DNS resolution to simulate network outage during active PutMedia streaming). Before the fix: `STATUS_DESCRIBE_STREAM_CALL_FAILED` (0x52000011) followed by buffer purge (dropped frames logs). After the fix: SDK retries PutMedia with backoff, buffer preserved (until it drop older frames due to a full buffer size).
- Existing unit tests pass (`cmake .. && make && ./tst/producerTest`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.