### PR TITLE
use computed back-off for emulated API calls

### DIFF
--- a/src/source/CallbacksProvider.c
+++ b/src/source/CallbacksProvider.c
@@ -474,6 +474,19 @@ CleanUp:
     return retStatus;
 }
 
+VOID honorCallAfterWaitTime(PCallbacksProvider pCallbacksProvider, PServiceCallContext pServiceCallContext)
+{
+    UINT64 currentTime;
+
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pCallbacksProvider != NULL && pServiceCallContext != NULL && pServiceCallContext->callAfter != 0) {
+        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
+    }
+}
+
 STATUS setPlatformCallbacks(PClientCallbacks pClientCallbacks, PPlatformCallbacks pPlatformCallbacks)
 {
     ENTERS();

--- a/src/source/CallbacksProvider.h
+++ b/src/source/CallbacksProvider.h
@@ -58,6 +58,16 @@ typedef struct __CallbacksProvider* PCallbacksProvider;
 STATUS setDefaultPlatformCallbacks(PCallbacksProvider);
 
 /**
+ * Blocks until the service call context's callAfter time is reached in order to honor
+ * the backoff wait time computed by the state machine retry strategy. No-op if callAfter
+ * is unset or already in the past.
+ *
+ * @param - PCallbacksProvider - IN - Callbacks provider used to retrieve the current time
+ * @param - PServiceCallContext - IN - Service call context carrying the callAfter deadline
+ */
+VOID honorCallAfterWaitTime(PCallbacksProvider, PServiceCallContext);
+
+/**
  * Creates a default callbacks provider.
  *
  * NOTE: The caller is responsible for releasing the structure by calling

--- a/src/source/CredentialProviderAuthCallbacks.c
+++ b/src/source/CredentialProviderAuthCallbacks.c
@@ -114,19 +114,13 @@ STATUS getStreamingTokenCredentialProviderFunc(UINT64 customData, PCHAR streamNa
     STATUS retStatus = STATUS_SUCCESS;
     PAwsCredentials pAwsCredentials;
     PAwsCredentialProvider pCredentialProvider;
-    UINT64 currentTime;
 
     PCredentialProviderAuthCallbacks pCredentialProviderAuthCallbacks = (PCredentialProviderAuthCallbacks) customData;
 
     CHK(pCredentialProviderAuthCallbacks != NULL, STATUS_NULL_ARG);
+
     // Respect the callAfter to honor backoff wait time from the state machine retry strategy
-    if (pServiceCallContext->callAfter != 0) {
-        currentTime = pCredentialProviderAuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn(
-            pCredentialProviderAuthCallbacks->pCallbacksProvider->clientCallbacks.customData);
-        if (currentTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
-        }
-    }
+    honorCallAfterWaitTime(pCredentialProviderAuthCallbacks->pCallbacksProvider, pServiceCallContext);
 
     pCredentialProvider = (PAwsCredentialProvider) pCredentialProviderAuthCallbacks->pCredentialProvider;
     CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));

--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -1113,6 +1113,7 @@ STATUS createStreamCachingCurl(UINT64 customData, PCHAR deviceName, PCHAR stream
     PCurlApiCallbacks pCurlApiCallbacks = (PCurlApiCallbacks) customData;
     PCallbacksProvider pCallbacksProvider = NULL;
     BOOL emulateApiCall = TRUE;
+    UINT64 currentTime;
 
     CHK(pCurlApiCallbacks != NULL && pCurlApiCallbacks->pCallbacksProvider != NULL && pServiceCallContext != NULL, STATUS_INVALID_ARG);
     pCallbacksProvider = pCurlApiCallbacks->pCallbacksProvider;
@@ -1128,6 +1129,14 @@ STATUS createStreamCachingCurl(UINT64 customData, PCHAR deviceName, PCHAR stream
 
         // Early return
         CHK(FALSE, retStatus);
+    }
+
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pServiceCallContext->callAfter != 0) {
+        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
     }
 
     DLOGV("[%s] No-op CreateStream API call", streamName);
@@ -1347,6 +1356,7 @@ STATUS describeStreamCachingCurl(UINT64 customData, PCHAR streamName, PServiceCa
     StreamDescription streamDescription;
     PStreamInfo pStreamInfo;
     BOOL emulateApiCall = TRUE;
+    UINT64 currentTime;
 
     CHK(pCurlApiCallbacks != NULL && pCurlApiCallbacks->pCallbacksProvider != NULL && pServiceCallContext != NULL, STATUS_INVALID_ARG);
     pCallbacksProvider = pCurlApiCallbacks->pCallbacksProvider;
@@ -1362,6 +1372,14 @@ STATUS describeStreamCachingCurl(UINT64 customData, PCHAR streamName, PServiceCa
 
         // Early return
         CHK(FALSE, retStatus);
+    }
+
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pServiceCallContext->callAfter != 0) {
+        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
     }
 
     // Get the stream info from the stream handle
@@ -1666,6 +1684,14 @@ STATUS getStreamingEndpointCachingCurl(UINT64 customData, PCHAR streamName, PCHA
     pCallbacksProvider = pCurlApiCallbacks->pCallbacksProvider;
 
     streamHandle = (STREAM_HANDLE) pServiceCallContext->customData;
+
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pServiceCallContext->callAfter != 0) {
+        curTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
+        if (curTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - curTime);
+        }
+    }
 
     // We check whether we have already made the call by checking
     // for the presence of the endpoint in the cache.
@@ -1998,6 +2024,7 @@ STATUS tagResourceCachingCurl(UINT64 customData, PCHAR streamArn, UINT32 tagCoun
     PCallbacksProvider pCallbacksProvider = NULL;
     STREAM_HANDLE streamHandle;
     BOOL emulateApiCall = TRUE;
+    UINT64 currentTime;
 
     CHK(pCurlApiCallbacks != NULL && pCurlApiCallbacks->pCallbacksProvider != NULL && pServiceCallContext != NULL, STATUS_INVALID_ARG);
     pCallbacksProvider = pCurlApiCallbacks->pCallbacksProvider;
@@ -2013,6 +2040,14 @@ STATUS tagResourceCachingCurl(UINT64 customData, PCHAR streamArn, UINT32 tagCoun
 
         // Early return
         CHK(FALSE, retStatus);
+    }
+
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    if (pServiceCallContext->callAfter != 0) {
+        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
+        if (currentTime < pServiceCallContext->callAfter) {
+            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
+        }
     }
 
     DLOGV("Caching TagResource API call");

--- a/src/source/CurlApiCallbacks.c
+++ b/src/source/CurlApiCallbacks.c
@@ -1132,12 +1132,7 @@ STATUS createStreamCachingCurl(UINT64 customData, PCHAR deviceName, PCHAR stream
     }
 
     // Respect the callAfter to honor backoff wait time from the state machine retry strategy
-    if (pServiceCallContext->callAfter != 0) {
-        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
-        if (currentTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
-        }
-    }
+    honorCallAfterWaitTime(pCallbacksProvider, pServiceCallContext);
 
     DLOGV("[%s] No-op CreateStream API call", streamName);
 
@@ -1375,12 +1370,7 @@ STATUS describeStreamCachingCurl(UINT64 customData, PCHAR streamName, PServiceCa
     }
 
     // Respect the callAfter to honor backoff wait time from the state machine retry strategy
-    if (pServiceCallContext->callAfter != 0) {
-        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
-        if (currentTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
-        }
-    }
+    honorCallAfterWaitTime(pCallbacksProvider, pServiceCallContext);
 
     // Get the stream info from the stream handle
     CHK_STATUS(kinesisVideoStreamGetStreamInfo(streamHandle, &pStreamInfo));
@@ -1686,12 +1676,7 @@ STATUS getStreamingEndpointCachingCurl(UINT64 customData, PCHAR streamName, PCHA
     streamHandle = (STREAM_HANDLE) pServiceCallContext->customData;
 
     // Respect the callAfter to honor backoff wait time from the state machine retry strategy
-    if (pServiceCallContext->callAfter != 0) {
-        curTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
-        if (curTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - curTime);
-        }
-    }
+    honorCallAfterWaitTime(pCallbacksProvider, pServiceCallContext);
 
     // We check whether we have already made the call by checking
     // for the presence of the endpoint in the cache.
@@ -2043,12 +2028,7 @@ STATUS tagResourceCachingCurl(UINT64 customData, PCHAR streamArn, UINT32 tagCoun
     }
 
     // Respect the callAfter to honor backoff wait time from the state machine retry strategy
-    if (pServiceCallContext->callAfter != 0) {
-        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
-        if (currentTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
-        }
-    }
+    honorCallAfterWaitTime(pCallbacksProvider, pServiceCallContext);
 
     DLOGV("Caching TagResource API call");
     retStatus = tagResourceResultEvent(streamHandle, SERVICE_CALL_RESULT_OK);

--- a/src/source/FileAuthCallbacks.c
+++ b/src/source/FileAuthCallbacks.c
@@ -116,19 +116,13 @@ STATUS getStreamingTokenFileFunc(UINT64 customData, PCHAR streamName, STREAM_ACC
     PAwsCredentialProvider pCredentialProvider;
     PCallbacksProvider pCallbacksProvider = NULL;
     PFileAuthCallbacks pFileAuthCallbacks = (PFileAuthCallbacks) customData;
-    UINT64 currentTime;
 
     CHK(pFileAuthCallbacks != NULL && pServiceCallContext != NULL, STATUS_NULL_ARG);
 
     pCallbacksProvider = pFileAuthCallbacks->pCallbacksProvider;
 
     // Respect the callAfter to honor backoff wait time from the state machine retry strategy
-    if (pServiceCallContext->callAfter != 0) {
-        currentTime = pCallbacksProvider->clientCallbacks.getCurrentTimeFn(pCallbacksProvider->clientCallbacks.customData);
-        if (currentTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
-        }
-    }
+    honorCallAfterWaitTime(pCallbacksProvider, pServiceCallContext);
 
     pCredentialProvider = (PAwsCredentialProvider) pFileAuthCallbacks->pCredentialProvider;
     CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));

--- a/src/source/IotAuthCallback.c
+++ b/src/source/IotAuthCallback.c
@@ -174,18 +174,11 @@ STATUS getStreamingTokenIotFunc(UINT64 customData, PCHAR streamName, STREAM_ACCE
     PAwsCredentialProvider pCredentialProvider;
     PCallbacksProvider pCallbacksProvider = NULL;
     PIotAuthCallbacks pIotAuthCallbacks = (PIotAuthCallbacks) customData;
-    UINT64 currentTime;
 
     CHK(pIotAuthCallbacks != NULL && pServiceCallContext != NULL, STATUS_NULL_ARG);
-    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
 
-    if (pServiceCallContext->callAfter != 0) {
-        currentTime = pIotAuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn(
-            pIotAuthCallbacks->pCallbacksProvider->clientCallbacks.customData);
-        if (currentTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
-        }
-    }
+    // Respect the callAfter to honor backoff wait time from the state machine retry strategy
+    honorCallAfterWaitTime(pIotAuthCallbacks->pCallbacksProvider, pServiceCallContext);
 
     pCallbacksProvider = pIotAuthCallbacks->pCallbacksProvider;
     pCredentialProvider = (PAwsCredentialProvider) pIotAuthCallbacks->pCredentialProvider;

--- a/src/source/StaticAuthCallbacks.c
+++ b/src/source/StaticAuthCallbacks.c
@@ -117,20 +117,13 @@ STATUS getStreamingTokenStaticFunc(UINT64 customData, PCHAR streamName, STREAM_A
     STATUS retStatus = STATUS_SUCCESS;
     PAwsCredentials pAwsCredentials;
     PAwsCredentialProvider pCredentialProvider;
-    UINT64 currentTime;
 
     PStaticAuthCallbacks pStaticAuthCallbacks = (PStaticAuthCallbacks) customData;
 
     CHK(pStaticAuthCallbacks != NULL && pServiceCallContext != NULL, STATUS_NULL_ARG);
 
     // Respect the callAfter to honor backoff wait time from the state machine retry strategy
-    if (pServiceCallContext->callAfter != 0) {
-        currentTime = pStaticAuthCallbacks->pCallbacksProvider->clientCallbacks.getCurrentTimeFn(
-            pStaticAuthCallbacks->pCallbacksProvider->clientCallbacks.customData);
-        if (currentTime < pServiceCallContext->callAfter) {
-            THREAD_SLEEP(pServiceCallContext->callAfter - currentTime);
-        }
-    }
+    honorCallAfterWaitTime(pStaticAuthCallbacks->pCallbacksProvider, pServiceCallContext);
 
     pCredentialProvider = (PAwsCredentialProvider) pStaticAuthCallbacks->pCredentialProvider;
     CHK_STATUS(pCredentialProvider->getCredentialsFn(pCredentialProvider, &pAwsCredentials));


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added `callAfter` enforcement to all four emulated/caching API call paths in `CurlApiCallbacks.c`: `describeStreamCachingCurl`, `createStreamCachingCurl`, `getStreamingEndpointCachingCurl`, and `tagResourceCachingCurl`.

*Why was it changed?*
- When API call caching is active (`API_CALL_CACHE_TYPE_ALL`, the default for kvssink and all samples), the state machine's exponential backoff wait time is passed via `pServiceCallContext->callAfter`. The real curl handler threads already honor this by sleeping before making the HTTP call. However, when the call is emulated (cache hit), the result event was fired synchronously without checking `callAfter`, effectively discarding the computed backoff.
- During a network outage with a fresh endpoint cache, this caused the state machine to cycle rapidly through emulated Describe → emulated GetEndpoint → cached GetToken → failed PutMedia at DNS-failure speed (~50 cycles/s). While the control-plane calls themselves are no-ops, each cycle reaches PutMedia which spawns a real thread, initializes a TLS session, signs the request, and attempts DNS resolution before failing, creating unnecessary churn, lock contention against `putFrame`, and a potential concurrent reconnect at fleet scale.

*How was it changed?*
- Added the same `callAfter` check-and-sleep pattern used by the auth callbacks and real curl handlers to each emulated path, before the result event is fired. For `getStreamingEndpointCachingCurl`, the sleep is placed before the endpoint cache lock acquisition to avoid holding the mutex during the wait.

*What testing was done for the changes?*
- Reproduced the tight retry loop locally (blocked DNS resolution during active PutMedia streaming with fresh endpoint cache). Before the fix: ~50 PutMedia attempts/s visible in DEBUG logs, retry counter climbing rapidly with computed waits of 10–19 s never applied. After the fix: retry attempts properly spaced at the computed backoff intervals.
- Existing unit tests pass (`cmake .. && make && ./tst/producerTest`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
